### PR TITLE
More UI tweaks

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -6,6 +6,7 @@ import { ControlPanel } from "./control-panel";
 import { Codap } from "../models/codap";
 import { IStringMap, SensorStrings, SensorDefinitions } from "../models/sensor-definitions";
 import SensorConnectorInterface from "@concord-consortium/sensor-connector-interface";
+import SmartFocusHighlight from "../utils/smart-focus-highlight";
 
 const SENSOR_IP = "http://127.0.0.1:11180";
 
@@ -90,6 +91,10 @@ export class App extends React.Component<AppProps, AppState> {
         this.toggleWarning = this.toggleWarning.bind(this);
         this.toggleGraph = this.toggleGraph.bind(this);
         this.reload = this.reload.bind(this);
+    }
+
+    componentDidMount() {
+        SmartFocusHighlight.enableFocusHighlightOnKeyDown();
     }
     
     connectCodap() {

--- a/src/components/control-panel.tsx
+++ b/src/components/control-panel.tsx
@@ -58,13 +58,13 @@ export const ControlPanel: React.SFC<IControlPanelProps> = (props) => {
               onClick={props.onStopCollecting} disabled={disableStopCollecting}>
         Stop
       </Button>
-      <Button className="newData control-panel-button"
-              onClick={props.onNewRun} disabled={disableNewData}>
-        New Run
-      </Button>
       <Button className="sendData control-panel-button"
               onClick={props.onSaveData} disabled={disableSendData}>
         Save Data
+      </Button>
+      <Button className="newData control-panel-button"
+              onClick={props.onNewRun} disabled={disableNewData}>
+        New Run
       </Button>
       <div className="right-controls">
         <div>

--- a/src/components/control-panel.tsx
+++ b/src/components/control-panel.tsx
@@ -1,4 +1,6 @@
 import * as React from "react";
+import Button from "./smart-highlight-button";
+import Select from "./smart-highlight-select";
 
 interface IControlPanelProps {
   sensorType:string;
@@ -44,22 +46,26 @@ export const ControlPanel: React.SFC<IControlPanelProps> = (props) => {
     <div className="control-panel">
       <div className="cc-logo" />
       <span className="duration-label">Duration:</span>
-      <select className="duration-select control-panel-select"
+      <Select className="duration-select control-panel-select"
               onChange={handleDurationChange} defaultValue={String(props.duration)}>
         {[durationOptions]}
-      </select>
-      <button className="startSensor control-panel-button" 
-        onClick={props.onStartCollecting}
-        disabled={disableStartCollecting}>Start</button>
-      <button className="stopSensor control-panel-button" 
-        onClick={props.onStopCollecting}
-        disabled={disableStopCollecting}>Stop</button>
-      <button className="newData control-panel-button" 
-        onClick={props.onNewRun} 
-        disabled={disableNewData}>New Run</button>
-      <button className="sendData control-panel-button" 
-        onClick={props.onSaveData} 
-        disabled={disableSendData}>Save Data</button>
+      </Select>
+      <Button className="startSensor control-panel-button"
+              onClick={props.onStartCollecting} disabled={disableStartCollecting}>
+        Start
+      </Button>
+      <Button className="stopSensor control-panel-button"
+              onClick={props.onStopCollecting} disabled={disableStopCollecting}>
+        Stop
+      </Button>
+      <Button className="newData control-panel-button"
+              onClick={props.onNewRun} disabled={disableNewData}>
+        New Run
+      </Button>
+      <Button className="sendData control-panel-button"
+              onClick={props.onSaveData} disabled={disableSendData}>
+        Save Data
+      </Button>
       <div className="right-controls">
         <div>
           <a onClick={props.onReloadPage}

--- a/src/components/graph-side-panel.tsx
+++ b/src/components/graph-side-panel.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { Format } from "../utils/format";
 import { SensorDefinitions } from "../models/sensor-definitions";
+import Button from "./smart-highlight-button";
+import Select from "./smart-highlight-select";
 
 interface IGraphSidePanelProps {
   width?:number;
@@ -60,12 +62,14 @@ export const GraphSidePanel: React.SFC<IGraphSidePanelProps> = (props) => {
       <label className="reading-label side-panel-item">Reading:</label>
       <label className="sensor-reading side-panel-item">{sensorReading()}</label>
       <label className="sensor-label side-panel-item">Sensor:</label>
-      <select className="sensor-select side-panel-item" onChange={handleSensorChange} defaultValue={sensorUnitStr}>
+      <Select className="sensor-select side-panel-item"
+              onChange={handleSensorChange} defaultValue={sensorUnitStr}>
         {sensorUnitOptions(sensorUnits)}
-      </select>
-      <button className="zero-button side-panel-item" onClick={handleZeroSensor} disabled={disableZeroSensor}>
+      </Select>
+      <Button className="zero-button side-panel-item"
+              onClick={handleZeroSensor} disabled={disableZeroSensor}>
         Zero Sensor
-      </button>
+      </Button>
     </div>
   );
 };

--- a/src/components/sensor-graph.tsx
+++ b/src/components/sensor-graph.tsx
@@ -119,7 +119,8 @@ export class SensorGraphImp extends React.Component<SensorGraphProps, SensorGrap
         }
         
         var timeColumn = dataset.columns[0].data;
-        var valueColumn = this.getDataColumn(this.props.sensor.valueUnit, dataset).data;
+        var dataColumn = this.getDataColumn(this.props.sensor.valueUnit, dataset);
+        var valueColumn = dataColumn && dataColumn.data;
         
         // columns aren't always updated together
         var newLength = Math.min(timeColumn.length, valueColumn.length);

--- a/src/components/smart-highlight-button.tsx
+++ b/src/components/smart-highlight-button.tsx
@@ -1,0 +1,41 @@
+/*
+ * This component is a very thin wrapper around a standard <button> designed to prevent
+ * extraneous focus highlighting added by browsers when clicking on a button while
+ * maintaining keyboard accessibility. For details, see
+ * https://www.paciellogroup.com/blog/2012/04/how-to-remove-css-outlines-in-an-accessible-manner/
+ */
+import * as React from "react";
+import SmartFocusHighlight from "../utils/smart-focus-highlight";
+
+interface ISmartHighlightButtonProps {
+  className:string;
+  [key:string]:any;
+}
+
+interface ISmartHighlightButtonState {}
+
+export default class SmartHighlightButton extends React.Component<
+                                                    ISmartHighlightButtonProps,
+                                                    ISmartHighlightButtonState> {
+  private elementRef:any;
+                                                      
+  // prevent extraneous focus highlight on click while maintaining keyboard accessibility
+  // see https://www.paciellogroup.com/blog/2012/04/how-to-remove-css-outlines-in-an-accessible-manner/
+  suppressFocusHighlight = () => {
+    SmartFocusHighlight.suppressFocusHighlight(this.elementRef);
+  }
+
+  render() {
+    const { className, ...others } = this.props,
+          classes = (className ? className + ' ' : '') +
+                      SmartFocusHighlight.kSmartFocusHighlightClass;
+    return (
+      <button className={classes} {...others}
+              ref={(elt) => this.elementRef = elt}
+              onMouseEnter={this.suppressFocusHighlight}
+              onMouseDown={this.suppressFocusHighlight}>
+        {this.props.children}
+      </button>
+    );
+  }
+}

--- a/src/components/smart-highlight-select.tsx
+++ b/src/components/smart-highlight-select.tsx
@@ -1,0 +1,41 @@
+/*
+ * This component is a very thin wrapper around a standard <select> designed to prevent
+ * extraneous focus highlighting added by browsers when clicking on a button while
+ * maintaining keyboard accessibility. For details, see
+ * https://www.paciellogroup.com/blog/2012/04/how-to-remove-css-outlines-in-an-accessible-manner/
+ */
+import * as React from "react";
+import SmartFocusHighlight from "../utils/smart-focus-highlight";
+
+interface ISmartHighlightSelectProps {
+  className:string;
+  [key:string]:any;
+}
+
+interface ISmartHighlightSelectState {}
+
+export default class SmartHighlightSelect extends React.Component<
+                                                    ISmartHighlightSelectProps,
+                                                    ISmartHighlightSelectState> {
+  private elementRef:any;
+
+  // prevent extraneous focus highlight on click while maintaining keyboard accessibility
+  // see https://www.paciellogroup.com/blog/2012/04/how-to-remove-css-outlines-in-an-accessible-manner/
+  suppressFocusHighlight = () => {
+    SmartFocusHighlight.suppressFocusHighlight(this.elementRef);
+  }
+
+  render() {
+    const { className, ...others } = this.props,
+          classes = (className ? className + ' ' : '') +
+                      SmartFocusHighlight.kSmartFocusHighlightClass;
+    return (
+      <select className={classes} {...others}
+              ref={(elt) => this.elementRef = elt}
+              onMouseEnter={this.suppressFocusHighlight}
+              onMouseDown={this.suppressFocusHighlight}>
+        {this.props.children}
+      </select>
+    );
+  }
+}

--- a/src/public/assets/css/app.css
+++ b/src/public/assets/css/app.css
@@ -9,6 +9,10 @@ input, textarea, select, button {
     font-size: 12px;
 }
 
+.disable-focus-highlight {
+    outline: none;
+}
+
 .app-top-bar {
     display: flex;
     flex-direction: row-reverse;

--- a/src/public/assets/css/app.css
+++ b/src/public/assets/css/app.css
@@ -21,6 +21,7 @@ input, textarea, select, button {
 
 .two-sensors-checkbox {
     margin-right: 62px;
+    user-select: none;
 }
 
 .dygraph-label {
@@ -40,6 +41,7 @@ input, textarea, select, button {
 
 .sensor-graph {
     flex: 1 1;
+    user-select: none;
 }
 
 .graph-rescale-button {
@@ -56,6 +58,7 @@ input, textarea, select, button {
 .graph-side-panel {
     display: flex;
     flex-direction: column;
+    user-select: none;
 }
 
 .side-panel-item {
@@ -89,6 +92,7 @@ input, textarea, select, button {
     background-color: white;
     display: flex;
     align-items: center;
+    user-select: none;
 }
 
 .control-panel .duration-label {

--- a/src/utils/smart-focus-highlight.ts
+++ b/src/utils/smart-focus-highlight.ts
@@ -1,0 +1,50 @@
+/*
+ * This component is a very thin wrapper around a standard button designed to prevent
+ * extraneous focus highlighting added by browsers when clicking on a button while
+ * maintaining keyboard accessibility. See
+ * https://www.paciellogroup.com/blog/2012/04/how-to-remove-css-outlines-in-an-accessible-manner/
+ * for details. The upshot is that we use mouse events on the button to disable the
+ * focus highlight -- mousing/clicking on a push button should not be used as an
+ * indicator that the user would like to keyboard-interact with that button, which
+ * is what focusing a clicked button implies.
+ * IMPORTANT: To maintain accessibility, there must be code somewhere to reenable
+ * the focus highlight when appropriate. This can be done for 'keydown' by calling
+ * enableButtonFocusHighlightOnKeyDown() during application/page initialization,
+ * or by adding your own event handler that calls enableButtonFocusHighlight().
+ */
+
+export default class SmartFocusHighlight {
+
+  // add to all elements to enable smart focus highlight functionality
+  static kSmartFocusHighlightClass = 'smart-focus-highlight';
+  // added to elements when appropriate to disable focus highlight
+  static kDisableFocusHighlightClass = 'disable-focus-highlight';
+  
+  // Installs a keydown handler on the document which will enable button focus highlighting.
+  // Should be called once during application initialization.
+  static enableFocusHighlightOnKeyDown() {
+    document.addEventListener('keydown', () => this.enableFocusHighlight());
+  }
+
+  // Enables button focus highlighting; designed to be called from the keydown handler above
+  // but available separately for implementations that require it.
+  static enableFocusHighlight() {
+    const controls = document.querySelectorAll(`.${this.kSmartFocusHighlightClass}`),
+          count = controls.length;
+    // cf. https://developer.mozilla.org/en-US/docs/Web/API/NodeList#Example
+    for (let i = 0; i < count; ++i) {
+      const control = controls[i];
+      if (control && control.className) {
+        // cf. http://stackoverflow.com/questions/195951/change-an-elements-class-with-javascript
+        control.className = control.className.replace(/(?:^|\s)no-focus-highlight(?!\S)/g , '');
+      }
+    }
+  }
+
+  // prevent extraneous focus highlight on click while maintaining keyboard accessibility
+  // see https://www.paciellogroup.com/blog/2012/04/how-to-remove-css-outlines-in-an-accessible-manner/
+  static suppressFocusHighlight(elt:HTMLElement) {
+    if (elt && elt.className.indexOf(this.kDisableFocusHighlightClass) < 0)
+      elt.className += ' ' + this.kDisableFocusHighlightClass;
+  }
+}


### PR DESCRIPTION
Enable smart (accessible) control focus highlighting
- enable focus highlight on keydown
- disable focus highlight on mouse events
Reorder control panel buttons [#144405755]
Disable distracting text selection on buttons, menus, etc.
