### PR TITLE
Sensor slot refactor; squash bugs

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -361,8 +361,7 @@ export class App extends React.Component<AppProps, AppState> {
         
         this.setState({
             xStart: xStart,
-            xEnd: xEnd,
-            dataChanged: true
+            xEnd: xEnd
         });
     }
 

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -266,6 +266,11 @@ export class App extends React.Component<AppProps, AppState> {
             sensorConfig: null
         });
     }
+
+    hasData() {
+        const { sensorSlots } = this.state;
+        return sensorSlots.some((slot) => slot.sensorData && (slot.sensorData.length > 0));
+    }
     
     sendData() {
         const { sensorSlots, secondGraph } = this.state,
@@ -297,6 +302,8 @@ export class App extends React.Component<AppProps, AppState> {
     }
     
     newData() {
+        const { sensorSlots } = this.state;
+        sensorSlots.forEach((slot) => slot.sensorData = []);
         this.setState({
             hasData:false,
             dataReset:true,
@@ -404,6 +411,7 @@ export class App extends React.Component<AppProps, AppState> {
                             isLastGraph={isLastGraph}
                             sensorColumns={sensorColumns}
                             collecting={this.state.collecting}
+                            hasData={this.hasData()}
                             dataReset={this.state.dataReset}/>;
     }
     

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -206,6 +206,11 @@ export class App extends React.Component<AppProps, AppState> {
         }
         this.setState({ sensorSlots });
     }
+
+    handleZeroSensor = (sensorSlot:SensorSlot, sensorValue:number) => {
+        sensorSlot.sensor.tareValue = sensorValue;
+        this.setState({ sensorSlots: this.state.sensorSlots });
+    }
     
     sensorHasData():boolean {
         return (this.sensorConnector &&
@@ -403,6 +408,7 @@ export class App extends React.Component<AppProps, AppState> {
                             sensorConnector={this.sensorConnector}
                             onGraphZoom={this.onGraphZoom} 
                             onSensorSelect={this.handleSensorSelect}
+                            onZeroSensor={this.handleZeroSensor}
                             onStopCollection={this.stopSensor}
                             runLength={this.state.runLength}
                             xStart={this.state.xStart}
@@ -410,6 +416,7 @@ export class App extends React.Component<AppProps, AppState> {
                             isSingletonGraph={isSingletonGraph}
                             isLastGraph={isLastGraph}
                             sensorColumns={sensorColumns}
+                            timeUnit={this.state.timeUnit}
                             collecting={this.state.collecting}
                             hasData={this.hasData()}
                             dataReset={this.state.dataReset}/>;

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -278,16 +278,21 @@ export class App extends React.Component<AppProps, AppState> {
     }
     
     sendData() {
-        const { sensorSlots, secondGraph } = this.state,
+        const { sensorSlots } = this.state,
               data = sensorSlots.map((slot) =>
                         slot.sensorData.slice(this.selectionRange.start, this.selectionRange.end)),
-              sendSecondSensorData = secondGraph && sensorSlots[1].isConnected;
+              sendSecondSensorData = sensorSlots[1].hasData;
         let names = sensorSlots.map((slot) => slot.sensor.definition.measurementName);
         if (!sendSecondSensorData) {
             this.codap.sendData(data[0], names[0]);   
         }
         else {
-            names = names.map((name, index) => `${name}_${index+1}`);
+            names = names.map((name, i) => {
+                const slot = sensorSlots[i],
+                      sensor = slot && slot.sensor,
+                      position = (sensor && sensor.sensorPosition) || i+1;
+                return `${name}_${position}`;
+            });
             this.codap.sendDualData(data[0], names[0], data[1], names[1]);
         }
         

--- a/src/components/graph-side-panel.tsx
+++ b/src/components/graph-side-panel.tsx
@@ -10,8 +10,8 @@ interface IGraphSidePanelProps {
   width?:number;
   sensorSlot:SensorSlot;
   sensorColumns:ISensorConfigColumnInfo[];
-  onZeroSensor:() => void;
   onSensorSelect?:(sensorIndex:number, columnID:string) => void;
+  onZeroSensor?:() => void;
 }
 
 export const GraphSidePanel: React.SFC<IGraphSidePanelProps> = (props) => {
@@ -65,7 +65,7 @@ export const GraphSidePanel: React.SFC<IGraphSidePanelProps> = (props) => {
         sensorOptions = sensorSelectOptions(props.sensorColumns),
         enableSensorSelect = sensorOptions && (sensorOptions.length > 1) && props.onSensorSelect,
         sensorDefinition = sensor && sensor.definition,
-        disableZeroSensor = !sensorDefinition || !sensorDefinition.tareable;
+        enableZeroSensor = sensorDefinition && sensorDefinition.tareable && props.onZeroSensor;
   return (
     <div className="graph-side-panel" style={style}>
       <label className="reading-label side-panel-item">Reading:</label>
@@ -80,7 +80,7 @@ export const GraphSidePanel: React.SFC<IGraphSidePanelProps> = (props) => {
         {sensorOptions}
       </Select>
       <Button className="zero-button side-panel-item"
-              onClick={handleZeroSensor} disabled={disableZeroSensor}>
+              onClick={handleZeroSensor} disabled={!enableZeroSensor}>
         Zero Sensor
       </Button>
     </div>

--- a/src/components/graph-side-panel.tsx
+++ b/src/components/graph-side-panel.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Format } from "../utils/format";
-import { Sensor } from "../models/sensor";
+import { SensorSlot } from "../models/sensor-slot";
 import { SensorDefinitions } from "../models/sensor-definitions";
 import { ISensorConfigColumnInfo } from "../models/sensor-connector-interface";
 import Button from "./smart-highlight-button";
@@ -8,14 +8,15 @@ import Select from "./smart-highlight-select";
 
 interface IGraphSidePanelProps {
   width?:number;
-  sensor:Sensor;
+  sensorSlot:SensorSlot;
   sensorColumns:ISensorConfigColumnInfo[];
   onZeroSensor:() => void;
   onSensorSelect:(sensorIndex:number, columnID:string) => void;
 }
 
 export const GraphSidePanel: React.SFC<IGraphSidePanelProps> = (props) => {
-  const { sensor, onZeroSensor, onSensorSelect } = props,
+  const { sensorSlot, onZeroSensor, onSensorSelect } = props,
+        { sensor } = sensorSlot,
         tareValue = sensor.tareValue || 0,
         sensorUnitStr = sensor.valueUnit || "";
   
@@ -25,15 +26,14 @@ export const GraphSidePanel: React.SFC<IGraphSidePanelProps> = (props) => {
   };
 
   const handleSensorSelect = (evt:React.FormEvent<HTMLSelectElement>) => {
-    if (onSensorSelect && (props.sensor.index != null)) {
+    if (onSensorSelect && (props.sensorSlot.slotIndex != null)) {
       const selectedColID = evt.currentTarget.value;
-      onSensorSelect(props.sensor.index, selectedColID);
+      onSensorSelect(props.sensorSlot.slotIndex, selectedColID);
     }
   };
 
   const sensorReading = () => {
-    const { sensor } = props,
-          sensorDefinition = sensor && sensor.definition,
+    const sensorDefinition = sensor && sensor.definition,
           sensorValue = sensor && sensor.sensorValue;
     if (!sensorDefinition || (sensorValue == null) || isNaN(sensorValue))
       return "";
@@ -45,7 +45,7 @@ export const GraphSidePanel: React.SFC<IGraphSidePanelProps> = (props) => {
   };
 
   const sensorSelectOptions = (sensorColumns:ISensorConfigColumnInfo[]) => {
-    if (sensor.index == null) return null;
+    if (sensorSlot.slotIndex == null) return null;
     return (sensorColumns || []).map((column:ISensorConfigColumnInfo, index:number) => {
       const units = column && column.units,
             columnID = column && column.id,
@@ -64,7 +64,7 @@ export const GraphSidePanel: React.SFC<IGraphSidePanelProps> = (props) => {
         style = width ? { flex: `0 0 ${width}px` } : {},
         sensorOptions = sensorSelectOptions(props.sensorColumns),
         enableSensorSelect = sensorOptions && (sensorOptions.length > 1),
-        sensorDefinition = props.sensor && props.sensor.definition,
+        sensorDefinition = sensor && sensor.definition,
         disableZeroSensor = !sensorDefinition || !sensorDefinition.tareable;
   return (
     <div className="graph-side-panel" style={style}>

--- a/src/components/graph-side-panel.tsx
+++ b/src/components/graph-side-panel.tsx
@@ -11,7 +11,7 @@ interface IGraphSidePanelProps {
   sensorSlot:SensorSlot;
   sensorColumns:ISensorConfigColumnInfo[];
   onZeroSensor:() => void;
-  onSensorSelect:(sensorIndex:number, columnID:string) => void;
+  onSensorSelect?:(sensorIndex:number, columnID:string) => void;
 }
 
 export const GraphSidePanel: React.SFC<IGraphSidePanelProps> = (props) => {
@@ -63,7 +63,7 @@ export const GraphSidePanel: React.SFC<IGraphSidePanelProps> = (props) => {
   const width = props.width && isFinite(props.width) ? props.width : null,
         style = width ? { flex: `0 0 ${width}px` } : {},
         sensorOptions = sensorSelectOptions(props.sensorColumns),
-        enableSensorSelect = sensorOptions && (sensorOptions.length > 1),
+        enableSensorSelect = sensorOptions && (sensorOptions.length > 1) && props.onSensorSelect,
         sensorDefinition = sensor && sensor.definition,
         disableZeroSensor = !sensorDefinition || !sensorDefinition.tareable;
   return (

--- a/src/components/sensor-graph.tsx
+++ b/src/components/sensor-graph.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Sensor } from "../models/sensor";
+import { SensorSlot } from "../models/sensor-slot";
 import { Graph } from "./graph";
 import { GraphSidePanel } from "./graph-side-panel";
 import { ISensorConfigColumnInfo,
@@ -22,7 +23,7 @@ export interface SensorGraphProps {
     size:ISizeMeSize;
     sensorConnector:any;
     sensorColumns:ISensorConfigColumnInfo[];
-    sensor:Sensor;
+    sensorSlot:SensorSlot;
     title:string;
     onGraphZoom:(xStart:number, xEnd:number) => void;
     onSensorSelect:(sensorIndex:number, columnID:string) => void;
@@ -58,7 +59,7 @@ export class SensorGraphImp extends React.Component<SensorGraphProps, SensorGrap
             sensorActive: false,
             sensorColID: undefined,
             sensorValue: undefined,
-            sensorData: this.props.sensor.sensorData,
+            sensorData: this.props.sensorSlot.sensorData,
             dataChanged: false,
             tareValue: 0,
             timeUnit: "s"
@@ -81,11 +82,11 @@ export class SensorGraphImp extends React.Component<SensorGraphProps, SensorGrap
     
     onSensorStatus = () => {
         // find the value for the currently selected sensor/unit type
-        var sensorColumnID = this.props.sensor.columnID,
-            dataColumn = sensorColumnID && this.getDataColumn(sensorColumnID),
+        const { sensor } = this.props.sensorSlot,
+            dataColumn = sensor.columnID && this.getDataColumn(sensor.columnID),
             liveValue = dataColumn ? Number(dataColumn.liveValue) : undefined;
         if(liveValue != null) {
-            this.props.sensor.sensorValue = liveValue;
+            sensor.sensorValue = liveValue;
             this.setState({ sensorValue: liveValue });
         }
         else {
@@ -111,7 +112,8 @@ export class SensorGraphImp extends React.Component<SensorGraphProps, SensorGrap
         
         const timeData = dataset.columns[0].data || [],
               timeDataLength = timeData.length,
-              dataColumn = this.getDataColumn(this.props.sensor.columnID, dataset),
+              { sensor } = this.props.sensorSlot,
+              dataColumn = this.getDataColumn(sensor.columnID, dataset),
               sensorData = (dataColumn && dataColumn.data) || [],
               sensorDataLength = sensorData.length;
         
@@ -138,7 +140,7 @@ export class SensorGraphImp extends React.Component<SensorGraphProps, SensorGrap
                 }
             }
             
-            this.props.sensor.sensorData = updatedData;
+            this.props.sensorSlot.sensorData = updatedData;
             this.setState({
                 sensorData: updatedData,
                 dataChanged: true
@@ -176,11 +178,12 @@ export class SensorGraphImp extends React.Component<SensorGraphProps, SensorGrap
         const height = this.props.isSingletonGraph
                         ? kSingletonGraphHeight
                         : (this.props.isLastGraph ? kGraphWithLabelHeight : kPairedGraphHeight),
-              sensorDefinition = this.props.sensor && this.props.sensor.definition,
+              { sensor } = this.props.sensorSlot,
+              sensorDefinition = sensor && sensor.definition,
               minReading = sensorDefinition && sensorDefinition.minReading,
               maxReading = sensorDefinition && sensorDefinition.maxReading,
               measurementName = (sensorDefinition && sensorDefinition.measurementName) || "",
-              valueUnit = this.props.sensor.valueUnit || "",
+              valueUnit = sensor.valueUnit || "",
               xLabel = this.props.isLastGraph ? `Time (${this.state.timeUnit})` : "",
               yLabel = measurementName
                         ? `${measurementName} (${valueUnit})`
@@ -207,7 +210,7 @@ export class SensorGraphImp extends React.Component<SensorGraphProps, SensorGrap
         return (
           <GraphSidePanel
             width={kSidePanelWidth}
-            sensor={this.props.sensor}
+            sensorSlot={this.props.sensorSlot}
             sensorColumns={this.props.sensorColumns}
             onZeroSensor={this.zeroSensor}
             onSensorSelect={this.props.onSensorSelect} />

--- a/src/components/sensor-graph.tsx
+++ b/src/components/sensor-graph.tsx
@@ -30,6 +30,7 @@ export interface SensorGraphProps {
     onStopCollection:() => void;
     runLength:number;
     collecting:boolean;
+    hasData:boolean;
     dataReset:boolean;
     xStart:number;
     xEnd:number;
@@ -207,13 +208,15 @@ export class SensorGraphImp extends React.Component<SensorGraphProps, SensorGrap
     }
 
     renderSidePanel() {
+        const { collecting, hasData } = this.props,
+              onSensorSelect = !collecting && !hasData ? this.props.onSensorSelect : undefined;
         return (
           <GraphSidePanel
             width={kSidePanelWidth}
             sensorSlot={this.props.sensorSlot}
             sensorColumns={this.props.sensorColumns}
             onZeroSensor={this.zeroSensor}
-            onSensorSelect={this.props.onSensorSelect} />
+            onSensorSelect={onSensorSelect} />
         );
     }
     

--- a/src/models/sensor-configuration.ts
+++ b/src/models/sensor-configuration.ts
@@ -10,7 +10,7 @@ export class SensorConfiguration {
   }
 
   get interface() {
-    return this.config.currentInterface;
+    return this.config && this.config.currentInterface;
   }
 
   get hasInterface() {

--- a/src/models/sensor-slot.ts
+++ b/src/models/sensor-slot.ts
@@ -1,0 +1,25 @@
+import { Sensor } from "./sensor";
+
+export class SensorSlot {
+  slotIndex:number;
+  sensor:Sensor;
+  sensorData:number[][];
+
+  constructor(index:number, sensor:Sensor) {
+    this.slotIndex = index;
+    this.sensor = sensor;
+    this.sensorData = [];
+  }
+
+  get isConnected() {
+    return this.sensor.isConnected;
+  }
+
+  setSensor(sensor:Sensor) {
+    this.sensor = sensor;
+  }
+
+  setData(sensorData:number[][]) {
+    this.sensorData = sensorData;
+  }
+}

--- a/src/models/sensor-slot.ts
+++ b/src/models/sensor-slot.ts
@@ -15,6 +15,10 @@ export class SensorSlot {
     return this.sensor.isConnected;
   }
 
+  get hasData() {
+    return this.sensorData && this.sensorData.length;
+  }
+
   setSensor(sensor:Sensor) {
     this.sensor = sensor;
   }

--- a/src/models/sensor.ts
+++ b/src/models/sensor.ts
@@ -4,7 +4,6 @@ export class Sensor {
     columnID?:string;
     sensorPosition?:number; // index in received dataColumns array
     sensorValue?:number;
-    sensorData:number[][];
     dataChanged:boolean;
     tareValue:number;
     timeUnit:string;
@@ -12,7 +11,6 @@ export class Sensor {
     definition:ISensorDefinition;
     
     constructor() {
-        this.sensorData = [];
         this.tareValue = 0;
         this.definition = {
             sensorName:"",
@@ -25,6 +23,6 @@ export class Sensor {
     }
 
     get isConnected() {
-        return this.columnID && this.sensorData && this.valueUnit;
+        return !!this.columnID && !!this.valueUnit;
     }
 }

--- a/src/models/sensor.ts
+++ b/src/models/sensor.ts
@@ -13,6 +13,7 @@ export class Sensor {
     
     constructor() {
         this.sensorData = [];
+        this.tareValue = 0;
         this.definition = {
             sensorName:"",
             measurementName:"",

--- a/src/models/sensor.ts
+++ b/src/models/sensor.ts
@@ -1,7 +1,6 @@
 import { ISensorDefinition } from "./sensor-connector-interface";
 
 export class Sensor {
-    index?:number;          // local index: 0 for top graph, 1 for bottom
     columnID?:string;
     sensorPosition?:number; // index in received dataColumns array
     sensorValue?:number;


### PR DESCRIPTION
- SensorSlot refactor
  - store slotIndex and sensorData[] with SensorSlot, rather than Sensor
- Disable sensor selection during (and after) data collection [#151258623]
- Fix behavior of zero sensor button [#151192918]
- Number of columns of data to save based on presence of data
  - previously, it was based on the "Two sensors" checkbox setting
  - fixes [#151272003], [#151271668], [#151271576], [#151300643]
- Use sensor position in interface for name suffix when exporting data [#151342403]
