### PR TITLE
Responsive resizing

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -433,7 +433,7 @@ export class App extends React.Component<AppProps, AppState> {
                         : "",
             interfaceType = (sensorConfig && sensorConfig.interface) || "";
         return (
-            <div>
+            <div className="app-container">
                 <ReactModal contentLabel="Discard data?" 
                     isOpen={this.state.warnNewModal}
                     style={{
@@ -463,19 +463,21 @@ export class App extends React.Component<AppProps, AppState> {
                     <button 
                         onClick={this.tryReconnectModal}>Try again</button>
                 </ReactModal>
-                <div className="app-top-bar">
-                    <label className="two-sensors-checkbox">
-                        <input type="checkbox" 
-                            id="toggleGraphBtn"
-                            onClick={this.toggleGraph} />
-                        Two sensors
-                    </label>
-                    <div>{this.state.statusMessage || "\xA0"}</div>
+                <div className="app-content">
+                    <div className="app-top-bar">
+                        <label className="two-sensors-checkbox">
+                            <input type="checkbox" 
+                                id="toggleGraphBtn"
+                                onClick={this.toggleGraph} />
+                            Two sensors
+                        </label>
+                        <div>{this.state.statusMessage || "\xA0"}</div>
+                    </div>
+                    {this.renderGraph(sensorSlots[0], "graph1", !secondGraph)}
+                    {secondGraph
+                        ? this.renderGraph(sensorSlots[1], "graph2", false, true)
+                        : null}
                 </div>
-                {this.renderGraph(sensorSlots[0], "graph1", !secondGraph)}
-                {secondGraph
-                    ? this.renderGraph(sensorSlots[1], "graph2", false, true)
-                    : null}
                 <ControlPanel   interfaceType={interfaceType}
                                 collecting={this.state.collecting}
                                 hasData={this.state.hasData}

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -4,7 +4,7 @@ import { Sensor } from "../models/sensor";
 import { SensorSlot } from "../models/sensor-slot";
 import { SensorConfiguration } from "../models/sensor-configuration";
 import { ISensorConfig, ISensorConfigColumnInfo } from "../models/sensor-connector-interface";
-import { SensorGraph } from "./sensor-graph";
+import GraphsPanel from "./graphs-panel";
 import { ControlPanel } from "./control-panel";
 import { Codap } from "../models/codap";
 import { IStringMap, SensorStrings, SensorDefinitions } from "../models/sensor-definitions";
@@ -405,29 +405,8 @@ export class App extends React.Component<AppProps, AppState> {
         }
     }
     
-    renderGraph(sensorSlot:SensorSlot, title:string, isSingletonGraph:boolean, isLastGraph:boolean = isSingletonGraph) {
-        const sensorColumns = this.state.sensorConfig && this.state.sensorConfig.dataColumns;
-        return <SensorGraph sensorSlot={sensorSlot}
-                            title={title} 
-                            sensorConnector={this.sensorConnector}
-                            onGraphZoom={this.onGraphZoom} 
-                            onSensorSelect={this.handleSensorSelect}
-                            onZeroSensor={this.handleZeroSensor}
-                            onStopCollection={this.stopSensor}
-                            runLength={this.state.runLength}
-                            xStart={this.state.xStart}
-                            xEnd={this.state.xEnd}
-                            isSingletonGraph={isSingletonGraph}
-                            isLastGraph={isLastGraph}
-                            sensorColumns={sensorColumns}
-                            timeUnit={this.state.timeUnit}
-                            collecting={this.state.collecting}
-                            hasData={this.hasData()}
-                            dataReset={this.state.dataReset}/>;
-    }
-    
     render() {
-        var { sensorConfig, sensorSlots, secondGraph } = this.state,
+        var { sensorConfig } = this.state,
             codapURL = window.self === window.top
                         ? "http://codap.concord.org/releases/latest?di=" + window.location.href
                         : "",
@@ -473,24 +452,38 @@ export class App extends React.Component<AppProps, AppState> {
                         </label>
                         <div>{this.state.statusMessage || "\xA0"}</div>
                     </div>
-                    {this.renderGraph(sensorSlots[0], "graph1", !secondGraph)}
-                    {secondGraph
-                        ? this.renderGraph(sensorSlots[1], "graph2", false, true)
-                        : null}
+                    <GraphsPanel
+                        sensorConnector={this.sensorConnector}
+                        sensorConfig={this.state.sensorConfig}
+                        sensorSlots={this.state.sensorSlots}
+                        secondGraph={this.state.secondGraph}
+                        onGraphZoom={this.onGraphZoom} 
+                        onSensorSelect={this.handleSensorSelect}
+                        onZeroSensor={this.handleZeroSensor}
+                        onStopCollection={this.stopSensor}
+                        xStart={this.state.xStart}
+                        xEnd={this.state.xEnd}
+                        timeUnit={this.state.timeUnit}
+                        runLength={this.state.runLength}
+                        collecting={this.state.collecting}
+                        hasData={this.hasData()}
+                        dataReset={this.state.dataReset}
+                    />
                 </div>
-                <ControlPanel   interfaceType={interfaceType}
-                                collecting={this.state.collecting}
-                                hasData={this.state.hasData}
-                                dataChanged={this.state.dataChanged}
-                                duration={10} durationUnit="s"
-                                durationOptions={[1, 5, 10, 15, 20, 30, 45, 60]}
-                                embedInCodapUrl={codapURL}
-                                onDurationChange={this.onTimeSelect}
-                                onStartCollecting={this.startSensor}
-                                onStopCollecting={this.stopSensor}
-                                onNewRun={this.checkNewData}
-                                onSaveData={this.sendData}
-                                onReloadPage={this.reload}
+                <ControlPanel
+                    interfaceType={interfaceType}
+                    collecting={this.state.collecting}
+                    hasData={this.state.hasData}
+                    dataChanged={this.state.dataChanged}
+                    duration={10} durationUnit="s"
+                    durationOptions={[1, 5, 10, 15, 20, 30, 45, 60]}
+                    embedInCodapUrl={codapURL}
+                    onDurationChange={this.onTimeSelect}
+                    onStartCollecting={this.startSensor}
+                    onStopCollecting={this.stopSensor}
+                    onNewRun={this.checkNewData}
+                    onSaveData={this.sendData}
+                    onReloadPage={this.reload}
                 />
             </div>
         );

--- a/src/components/graph-side-panel.tsx
+++ b/src/components/graph-side-panel.tsx
@@ -61,7 +61,7 @@ export const GraphSidePanel: React.SFC<IGraphSidePanelProps> = (props) => {
   };
 
   const width = props.width && isFinite(props.width) ? props.width : null,
-        style = width ? { flex: `0 0 ${width}px` } : {},
+        style = width ? { width } : {},
         sensorOptions = sensorSelectOptions(props.sensorColumns),
         enableSensorSelect = sensorOptions && (sensorOptions.length > 1) && props.onSensorSelect,
         sensorDefinition = sensor && sensor.definition,

--- a/src/components/graph.tsx
+++ b/src/components/graph.tsx
@@ -4,8 +4,8 @@ import { Format } from "../utils/format";
 
 export interface GraphProps {
     title:string|undefined;
-    width?:number;
-    height?:number;
+    width:number|null;
+    height:number|null;
     data:number[][];
     onZoom:(xStart:number, xEnd:number) => void;
     xMin:number;
@@ -18,8 +18,8 @@ export interface GraphProps {
 }
 
 export interface GraphState {
-    width?:number;
-    height?:number;
+    width:number|null;
+    height:number|null;
     data:number[][];
     xMin:number;
     xMax:number;

--- a/src/components/graphs-panel.tsx
+++ b/src/components/graphs-panel.tsx
@@ -1,0 +1,87 @@
+import * as React from "react";
+import { SensorConfiguration } from "../models/sensor-configuration";
+import SensorGraph from "./sensor-graph";
+import { SensorSlot } from "../models/sensor-slot";
+import sizeMe from "react-sizeme";
+
+interface ISizeMeSize {
+  width:number|null;
+  height:number|null;
+}
+
+interface IGraphsPanelProps {
+  size:ISizeMeSize;
+  sensorConnector:any;
+  sensorConfig:SensorConfiguration|null;
+  sensorSlots:SensorSlot[];
+  secondGraph:boolean;
+  onGraphZoom:(xStart:number, xEnd:number) => void;
+  onSensorSelect:(sensorIndex:number, columnID:string) => void;
+  onZeroSensor:(sensorSlot:SensorSlot, sensorValue:number) => void;
+  onStopCollection:() => void;
+  xStart:number;
+  xEnd:number;
+  timeUnit:string;
+  runLength:number;
+  collecting:boolean;
+  hasData:boolean;
+  dataReset:boolean;
+}
+
+const GraphsPanelImp: React.SFC<IGraphsPanelProps> = (props) => {
+  
+  function renderGraph( sensorSlot:SensorSlot,
+                        title:string,
+                        isSingletonGraph:boolean,
+                        isLastGraph:boolean = isSingletonGraph) { 
+
+    const sensorColumns = (props.sensorConfig && props.sensorConfig.dataColumns) || [],
+          availableHeight = props.size.height && (props.size.height - 20),
+          singleGraphHeight = availableHeight && (availableHeight + 8),
+          graphBaseHeight = availableHeight && Math.floor((availableHeight - 18) / 2),
+          firstGraphHeight = graphBaseHeight,
+          secondGraphHeight = availableHeight && graphBaseHeight && (availableHeight - graphBaseHeight),
+          graphWidth = props.size.width && (props.size.width - 16),
+          graphHeight = isSingletonGraph
+                          ? singleGraphHeight
+                          : isLastGraph ? secondGraphHeight : firstGraphHeight;
+    return <SensorGraph width={graphWidth}
+                        height={graphHeight}
+                        sensorConnector={props.sensorConnector}
+                        sensorColumns={sensorColumns}
+                        sensorSlot={sensorSlot}
+                        title={title}
+                        isSingletonGraph={isSingletonGraph}
+                        isLastGraph={isLastGraph}
+                        onGraphZoom={props.onGraphZoom} 
+                        onSensorSelect={props.onSensorSelect}
+                        onZeroSensor={props.onZeroSensor}
+                        onStopCollection={props.onStopCollection}
+                        xStart={props.xStart}
+                        xEnd={props.xEnd}
+                        timeUnit={props.timeUnit}
+                        runLength={props.runLength}
+                        collecting={props.collecting}
+                        hasData={props.hasData}
+                        dataReset={props.dataReset}/>;
+  }
+
+  var { sensorSlots, secondGraph } = props;
+  
+  return (
+      <div className={`graphs-panel ${secondGraph ? 'two-graphs' : ''}`}>
+        {renderGraph(sensorSlots && sensorSlots[0], "graph1", !secondGraph)}
+        {secondGraph
+            ? renderGraph(sensorSlots && sensorSlots[1], "graph2", false, true)
+            : null}
+      </div>
+    );
+};
+
+const sizeMeConfig = {
+  monitorWidth: true,
+  monitorHeight: true,
+  noPlaceholder: true
+};
+const GraphsPanel = sizeMe(sizeMeConfig)(GraphsPanelImp);
+export default GraphsPanel;

--- a/src/components/sensor-graph.tsx
+++ b/src/components/sensor-graph.tsx
@@ -7,11 +7,11 @@ import { ISensorConfigColumnInfo,
          ISensorConnectorDataset } from "../models/sensor-connector-interface";
 import sizeMe from "react-sizeme";
 
-const kSidePanelWidth = 160,
-      kPairedGraphHeight = 190,
+const kSidePanelWidth = 200,
+      kPairedGraphHeight = 160,
       kGraphLabelHeight = 18,
       kGraphWithLabelHeight = kPairedGraphHeight + kGraphLabelHeight,
-      kBetweenGraphMargin = 10,
+      kBetweenGraphMargin = 22,
       kSingletonGraphHeight = kGraphWithLabelHeight + kBetweenGraphMargin + kPairedGraphHeight;
 
 interface ISizeMeSize {
@@ -211,7 +211,6 @@ export class SensorGraphImp extends React.Component<SensorGraphProps, SensorGrap
               onZeroSensor = !collecting && !hasData ? this.zeroSensor : undefined;
         return (
           <GraphSidePanel
-            width={kSidePanelWidth}
             sensorSlot={this.props.sensorSlot}
             sensorColumns={this.props.sensorColumns}
             onSensorSelect={onSensorSelect}

--- a/src/components/sensor-graph.tsx
+++ b/src/components/sensor-graph.tsx
@@ -5,22 +5,12 @@ import { Graph } from "./graph";
 import { GraphSidePanel } from "./graph-side-panel";
 import { ISensorConfigColumnInfo,
          ISensorConnectorDataset } from "../models/sensor-connector-interface";
-import sizeMe from "react-sizeme";
 
-const kSidePanelWidth = 200,
-      kPairedGraphHeight = 160,
-      kGraphLabelHeight = 18,
-      kGraphWithLabelHeight = kPairedGraphHeight + kGraphLabelHeight,
-      kBetweenGraphMargin = 22,
-      kSingletonGraphHeight = kGraphWithLabelHeight + kBetweenGraphMargin + kPairedGraphHeight;
+const kSidePanelWidth = 200;
 
-interface ISizeMeSize {
-    width?:number;
-    height?:number;
-}
-
-export interface SensorGraphProps {
-    size:ISizeMeSize;
+interface SensorGraphProps {
+    width:number|null;
+    height:number|null;
     sensorConnector:any;
     sensorColumns:ISensorConfigColumnInfo[];
     sensorSlot:SensorSlot;
@@ -40,7 +30,7 @@ export interface SensorGraphProps {
     isLastGraph:boolean;
 }
 
-export interface SensorGraphState {
+interface SensorGraphState {
     sensorActive:boolean;
     sensorColID?:string;
     sensorValue:number|undefined;
@@ -48,7 +38,7 @@ export interface SensorGraphState {
     dataChanged:boolean;
 }
 
-export class SensorGraphImp extends React.Component<SensorGraphProps, SensorGraphState> {
+export default class SensorGraph extends React.Component<SensorGraphProps, SensorGraphState> {
     
     sensor:Sensor;
     lastDataIndex:number = 0;
@@ -173,11 +163,8 @@ export class SensorGraphImp extends React.Component<SensorGraphProps, SensorGrap
         }
     }
     
-    renderGraph(graphWidth?:number) {
-        const height = this.props.isSingletonGraph
-                        ? kSingletonGraphHeight
-                        : (this.props.isLastGraph ? kGraphWithLabelHeight : kPairedGraphHeight),
-              { sensor } = this.props.sensorSlot,
+    renderGraph(graphWidth:number|null) {
+        const { sensor } = this.props.sensorSlot,
               sensorDefinition = sensor && sensor.definition,
               minReading = sensorDefinition && sensorDefinition.minReading,
               maxReading = sensorDefinition && sensorDefinition.maxReading,
@@ -192,7 +179,7 @@ export class SensorGraphImp extends React.Component<SensorGraphProps, SensorGrap
               <Graph 
                 title={this.props.title}
                 width={graphWidth}
-                height={height}
+                height={this.props.height}
                 data={this.state.sensorData} 
                 onZoom={this.props.onGraphZoom}
                 xMin={this.props.xStart}
@@ -219,8 +206,7 @@ export class SensorGraphImp extends React.Component<SensorGraphProps, SensorGrap
     }
     
     render() {
-        const { width } = this.props.size,
-              graphWidth = width != null ? width - kSidePanelWidth : undefined;
+        const graphWidth = this.props.width && (this.props.width - kSidePanelWidth);
         return (
             <div className="sensor-graph-panel">
                 {this.renderGraph(graphWidth)}
@@ -229,9 +215,3 @@ export class SensorGraphImp extends React.Component<SensorGraphProps, SensorGrap
         );
     }
 }
-
-const sizeMeConfig = {
-        monitorWidth: true,
-        noPlaceholder: true
-      };
-export const SensorGraph = sizeMe(sizeMeConfig)(SensorGraphImp);

--- a/src/models/codap.ts
+++ b/src/models/codap.ts
@@ -36,7 +36,7 @@ export class Codap {
         CodapInterface.init({
             name: this.dataSetName,
             title: this.dataSetTitle,
-            dimensions: {width: 460, height: 500},
+            dimensions: {width: 800, height: 490},
             version: '0.1'
         }, this.responseCallback).then((iResult) => {
             // get interactive state so we can save the data set index.

--- a/src/public/assets/css/app.css
+++ b/src/public/assets/css/app.css
@@ -2,6 +2,8 @@ body {
     background-color: #F9EDC3;
     font-family: Lato, Verdana, Geneva, sans-serif;
     font-size: 12px;
+    margin: 0;
+    overflow: hidden;
 }
 
 input, textarea, select, button {
@@ -11,6 +13,18 @@ input, textarea, select, button {
 
 .disable-focus-highlight {
     outline: none;
+}
+
+.app-container {
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    overflow: hidden;
+}
+
+.app-content {
+    margin-top: 8px;
 }
 
 .app-top-bar {
@@ -33,9 +47,7 @@ input, textarea, select, button {
 }
 
 .sensor-graph-panel {
-    width: 98%;
-    margin-top: 10px;
-    margin-bottom: 10px;
+    margin: 8px;
     display: flex;
 }
 
@@ -56,6 +68,8 @@ input, textarea, select, button {
 }
 
 .graph-side-panel {
+    width: 200px;
+    flex: 0 0;
     display: flex;
     flex-direction: column;
     user-select: none;
@@ -67,10 +81,14 @@ input, textarea, select, button {
     margin-right: 10px;
 }
 
+.reading-label {
+    margin-top: 8px;
+}
+
 .sensor-reading-surround {
     width: 100px;
     height: 24px;
-    margin-left: 32px;
+    margin-left: 42px;
     margin-bottom: 8px;
     background-color: white;
     border-radius: 5px;
@@ -86,6 +104,10 @@ input, textarea, select, button {
     text-align: center;
 }
 
+.sensor-label {
+    margin-top: 8px;
+}
+
 .sensor-select {
     background-color: #eee;
 }
@@ -94,16 +116,15 @@ input, textarea, select, button {
     width: 100px;
     background-color: #eee;
     border-radius: 4px;
-    margin-left: 33px;
+    margin-left: 42px;
     margin-top: 20px;
-    margin-bottom: 20px;
+    margin-bottom: 10px;
 }
 
 .control-panel {
     width: 100vw;
-    height: 40px;
+    flex: 0 0 44px;
     margin-top: 20px;
-    margin-left: -8px;
     background-color: white;
     display: flex;
     align-items: center;
@@ -133,8 +154,8 @@ input, textarea, select, button {
 
 .cc-logo {
     /* 354 x 110 native */
-    width: 122px;
-    height: 38px;
+    width: 116px;
+    height: 36px;
     min-width: 42px;
     margin-left: 6px;
     margin-right: 10px;
@@ -152,11 +173,11 @@ input, textarea, select, button {
 
 .embed-codap-link {
     margin-top: 4px;
-    margin-right: 16px;
+    margin-right: 8px;
 }
 
 .reload-page-button {
-    margin-right: 16px;
+    margin-right: 8px;
     opacity: 0.5;
 }
 

--- a/src/public/assets/css/app.css
+++ b/src/public/assets/css/app.css
@@ -24,10 +24,14 @@ input, textarea, select, button {
 }
 
 .app-content {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1;
     margin-top: 8px;
 }
 
 .app-top-bar {
+    flex: 0 0 18px;
     display: flex;
     flex-direction: row-reverse;
     justify-content: space-between;
@@ -36,6 +40,11 @@ input, textarea, select, button {
 .two-sensors-checkbox {
     margin-right: 62px;
     user-select: none;
+}
+
+.graphs-panel {
+    min-height: 370px;
+    flex: 1 1;
 }
 
 .dygraph-label {
@@ -122,6 +131,7 @@ input, textarea, select, button {
 }
 
 .control-panel {
+    z-index: 1;
     width: 100vw;
     flex: 0 0 44px;
     margin-top: 20px;


### PR DESCRIPTION
Responsive resizing round 1
- control panel/bar fixed to bottom of window
- plugin window defaults to 800x500 [#150895957]
- fixed height graph; vertical resize results in gap betwen graph and control panel
- side panel resizes more responsively

Responsive resizing round 2
- introduce `GraphsPanel` component to coordinate `SensorGraph` components
- move `sizeMe` from `SensorGraph` to `GraphsPanel`
- `SensorGraph` size computed dynamically by `GraphsPanel` rather than hard-coded to fixed size [#150896068]
- introduce minimum size for `GraphsPanel` so it won't try to get _too_ small
- Add z-index to `ControlPanel` so it floats on top of graphs (remains visible) at small sizes
