### PR TITLE
Dialog styling

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -413,34 +413,26 @@ export class App extends React.Component<AppProps, AppState> {
             interfaceType = (sensorConfig && sensorConfig.interface) || "";
         return (
             <div className="app-container">
-                <ReactModal contentLabel="Discard data?" 
-                    isOpen={this.state.warnNewModal}
-                    style={{
-                        content: {
-                            bottom: "auto"
-                        }
-                    }}>
+                <ReactModal className="sensor-dialog-content"
+                            overlayClassName="sensor-dialog-overlay"
+                            contentLabel="Discard data?" 
+                            isOpen={this.state.warnNewModal} >
                     <p>{this.messages["check_save"]}</p>
-                    <input type="checkbox" 
-                        onChange={this.toggleWarning}/><label>Don't show this message again</label>
+                    <label>
+                        <input type="checkbox" onChange={this.toggleWarning}/>
+                        Don't show this message again
+                    </label>
                     <hr/>
-                    <button 
-                        onClick={this.closeWarnNewModal}>Go back</button>
-                    <button
-                        onClick={this.discardData}>Discard the data</button>
+                    <button onClick={this.closeWarnNewModal}>Preserve Data</button>
+                    <button onClick={this.discardData}>Discard Data</button>
                 </ReactModal>
-                <ReactModal contentLabel="Sensor not attached" 
-                    isOpen={this.state.reconnectModal}
-                    style={{
-                        content: {
-                            bottom: "auto"
-                        }
-                    }}>
+                <ReactModal className="sensor-dialog-content"
+                            overlayClassName="sensor-dialog-overlay"
+                            contentLabel="Sensor not attached" 
+                            isOpen={this.state.reconnectModal} >
                     <p>{this.messages["sensor_not_attached"]}</p>
-                    
                     <hr/>
-                    <button 
-                        onClick={this.tryReconnectModal}>Try again</button>
+                    <button onClick={this.tryReconnectModal}>Try again</button>
                 </ReactModal>
                 <div className="app-content">
                     <div className="app-top-bar">

--- a/src/models/sensor-definitions.ts
+++ b/src/models/sensor-definitions.ts
@@ -62,7 +62,7 @@ export const SensorStrings:ISensorStrings = {
       "java_applet_error": "It appears that Java applets cannot run in your browser. If you are able to fix this, reload the page to use the sensor",
       "java_applet_not_loading": "The sensor applet appears not to be loading. If you are able to fix this, reload the page to use the sensor",
       "unexpected_error": "There was an unexpected error when connecting to the sensor.",
-      "sensor_not_attached": "The sensor does not appear to be attached. Try re-attaching it, and then click \"Try Again\"",
+      "sensor_not_attached": "No sensors appear to be attached. Try attaching one or more sensors and then click \"Try Again\".",
       "sensor_or_device_unplugged": "The __sensor_or_device_name__ was unplugged. Try plugging it back in, and then click \"$t(sensor.messages.try_again)\".",
       "try_again": "Try Again",
       "cancel": "Cancel",

--- a/src/public/assets/css/dialog.css
+++ b/src/public/assets/css/dialog.css
@@ -1,0 +1,46 @@
+.sensor-dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.sensor-dialog-content {
+  position: fixed;
+  top: 30%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 600px;
+  max-width: 90%;
+  bottom: auto;
+  border: 1px solid #ccc;
+  background: white;
+  overflow: auto;
+  border-radius: 4px;
+  outline: none;
+  padding: 20px;
+  font-size: 15px;
+  -webkit-overflow-scrolling: touch;
+}
+
+.sensor-dialog-content label {
+  user-select: none;
+}
+
+.sensor-dialog-content label input {
+  margin-right: 6px;
+}
+
+.sensor-dialog-content hr {
+  margin-top: 1.5em;
+  margin-bottom: 1.5em;
+}
+
+.sensor-dialog-content button {
+  float: right;
+  margin-left: 12px;
+  font-size: 15px;
+  user-select: none;
+}

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -9,6 +9,7 @@
     <!-- TODO: bundle with WebPack -->
     <link rel="stylesheet" href="assets/fonts/font-awesome-4.7.0/css/font-awesome.css">
     <link rel="stylesheet" href="assets/css/dygraph.css">
+    <link rel="stylesheet" href="assets/css/dialog.css">
     <link rel="stylesheet" href="assets/css/app.css">
   </head>
   <body>


### PR DESCRIPTION
Improve dialog styling [#150717386]
- dialogs sized and centered reasonably
- dialogs responsive to changing plugin size
- increase font size
- add white space around elements
- "Don't show again" label is clickable
- buttons larger
- button text not selectable
- move dialog styling from JavaScript to CSS

Note: this PR is based on PR #7 and PR #8. It should be rebased before merging.