### PR TITLE
Fix tick labels & rescale behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,12 @@
         }
       }
     },
+    "@types/d3-format": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.2.1.tgz",
+      "integrity": "sha512-dXhA9jzCbzu6Va8ZVUQ60nu6jqA5vhPhKGR4nY3lDYfjT05GyKEKuEhfwTaSTybWczY4nLEkzv9wLQCQd5+3cA==",
+      "dev": true
+    },
     "@types/dygraphs": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/dygraphs/-/dygraphs-1.1.4.tgz",
@@ -976,6 +982,11 @@
       "requires": {
         "es5-ext": "0.10.30"
       }
+    },
+    "d3-format": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.0.tgz",
+      "integrity": "sha1-a0gLqohohdRlHcJIqPSsnaFtsHo="
     },
     "date-now": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "homepage": "https://github.com/concord-consortium/sensor-interactive#readme",
   "dependencies": {
     "@concord-consortium/sensor-connector-interface": "^0.1.0",
+    "d3-format": "^1.2.0",
     "dygraphs": "^2.0.0",
     "iframe-phone": "^1.2.0",
     "lodash": "^4.17.4",
@@ -41,6 +42,7 @@
     "react-sizeme": "^2.3.4"
   },
   "devDependencies": {
+    "@types/d3-format": "^1.2.1",
     "@types/dygraphs": "^1.1.4",
     "@types/lodash": "^4.14.74",
     "@types/react": "^16.0.5",

--- a/src/components/graph-side-panel.tsx
+++ b/src/components/graph-side-panel.tsx
@@ -10,6 +10,7 @@ interface IGraphSidePanelProps {
   width?:number;
   sensorSlot:SensorSlot;
   sensorColumns:ISensorConfigColumnInfo[];
+  sensorPrecision:number;
   onSensorSelect?:(sensorIndex:number, columnID:string) => void;
   onZeroSensor?:() => void;
 }
@@ -33,13 +34,11 @@ export const GraphSidePanel: React.SFC<IGraphSidePanelProps> = (props) => {
   };
 
   const sensorReading = () => {
-    const sensorDefinition = sensor && sensor.definition,
-          sensorValue = sensor && sensor.sensorValue;
-    if (!sensorDefinition || (sensorValue == null) || isNaN(sensorValue))
+    const sensorValue = sensor && sensor.sensorValue;
+    if ((sensorValue == null) || isNaN(sensorValue))
       return "";
 
-    const sensorRange = sensorDefinition.maxReading - sensorDefinition.minReading,
-          sensorPrecision = Format.getFixValue(sensorRange),
+    const { sensorPrecision } = props,
           reading = Format.formatFixedValue(sensorValue - tareValue, sensorPrecision);
     return (sensorUnitStr) ? `${reading} ${sensorUnitStr}` : reading;
   };

--- a/src/components/graph.tsx
+++ b/src/components/graph.tsx
@@ -7,7 +7,7 @@ export interface GraphProps {
     width:number|null;
     height:number|null;
     data:number[][];
-    onZoom:(xStart:number, xEnd:number) => void;
+    onRescale:(xRange:number[], yRange:number[]) => void;
     xMin:number;
     xMax:number;
     yMin:number;
@@ -61,13 +61,11 @@ export class Graph extends React.Component<GraphProps, GraphState> {
             xLabel: this.props.xLabel,
             yLabel: this.props.yLabel,
             xAxisFix: Format.getAxisFix('x', this.props.xMax - this.props.xMin, this.props.width),
-            yAxisFix: Format.getAxisFix('y', this.props.yMax - this.props.yMin, this.props.height),
+            yAxisFix: Format.getAxisFix('y', this.props.yMax - this.props.yMin, this.props.height)
         };
         
         this.dyUpdateProps = ["width", "height", "xMin", "xMax", "yMin", "yMax",
                                 "valuePrecision", "xLabel", "yLabel"];
-        this.autoScale = this.autoScale.bind(this);
-        this.onZoom = this.onZoom.bind(this);
     }
     
     update():void {
@@ -89,19 +87,19 @@ export class Graph extends React.Component<GraphProps, GraphState> {
         (this.dygraph.resize as FResize)();
     }
 
-    autoScale() {
+    autoScale = () => {
         if (this.state.data && (this.state.data.length > 1))
             this.dygraph.resetZoom();
     }
     
-    onZoom(xStart:number, xEnd:number) {
+    onRescale = (xStart:number, xEnd:number, yRanges:number[][]) => {
         var yRange = this.dygraph.yAxisRange();
         var xRange = this.dygraph.xAxisRange();
         this.setState({
             xAxisFix: Format.getAxisFix('x', xRange[1] - xRange[0], this.props.width),
             yAxisFix: Format.getAxisFix('y', yRange[1] - yRange[0], this.props.height)
         });
-        this.props.onZoom(xStart, xEnd);
+        this.props.onRescale(xRange, yRange);
     }
     
     componentDidMount() {
@@ -109,7 +107,7 @@ export class Graph extends React.Component<GraphProps, GraphState> {
             dyGraphData(this.state.data), {
             dateWindow: [0, this.state.xMax],
             valueRange: [this.state.yMin, this.state.yMax],
-            zoomCallback: this.onZoom,
+            zoomCallback: this.onRescale,
             axes: {
                 x: {
                     valueFormatter: (val:number) => {
@@ -127,7 +125,8 @@ export class Graph extends React.Component<GraphProps, GraphState> {
                     },
                     axisLabelFormatter: (val:number) => {
                         return Format.formatFixedValue(val, this.state.yAxisFix, "", true);
-                    }
+                    },
+                    axisLabelWidth: 75
                 }
             },
             xlabel: this.state.xLabel,

--- a/src/components/sensor-graph.tsx
+++ b/src/components/sensor-graph.tsx
@@ -5,7 +5,8 @@ import { Graph } from "./graph";
 import { GraphSidePanel } from "./graph-side-panel";
 import { ISensorConfigColumnInfo,
          ISensorConnectorDataset } from "../models/sensor-connector-interface";
-
+import { Format } from "../utils/format";
+         
 const kSidePanelWidth = 200;
 
 interface SensorGraphProps {
@@ -60,6 +61,18 @@ export default class SensorGraph extends React.Component<SensorGraphProps, Senso
     componentWillUnmount() {
         this.props.sensorConnector.off("statusReceived", this.onSensorStatus);
         this.props.sensorConnector.off("data", this.onSensorData);
+    }
+
+    sensorPrecision() {
+        const { sensorSlot } = this.props,
+              sensor = sensorSlot && sensorSlot.sensor,
+              sensorDefinition = sensor && sensor.definition;
+        if (!sensorDefinition)
+            return 2;
+
+        const sensorRange = sensorDefinition.maxReading - sensorDefinition.minReading,
+              sensorPrecision = Format.getFixValue(sensorRange);
+        return sensorPrecision;
     }
     
     zeroSensor = () => {
@@ -181,6 +194,7 @@ export default class SensorGraph extends React.Component<SensorGraphProps, Senso
                 xMax={this.props.xEnd}
                 yMin={minReading != null ? minReading : 0}
                 yMax={maxReading != null ? maxReading : 10}
+                valuePrecision={this.sensorPrecision()}
                 xLabel={xLabel}
                 yLabel={yLabel} />
             </div>
@@ -195,6 +209,7 @@ export default class SensorGraph extends React.Component<SensorGraphProps, Senso
           <GraphSidePanel
             sensorSlot={this.props.sensorSlot}
             sensorColumns={this.props.sensorColumns}
+            sensorPrecision={this.sensorPrecision()}
             onSensorSelect={onSensorSelect}
             onZeroSensor={onZeroSensor} />
         );

--- a/src/components/sensor-graph.tsx
+++ b/src/components/sensor-graph.tsx
@@ -36,7 +36,10 @@ interface SensorGraphState {
     sensorActive:boolean;
     sensorColID?:string;
     sensorValue:number|undefined;
+    sensorUnit?:string;
     dataChanged:boolean;
+    yMin?:number|null;
+    yMax?:number|null;
 }
 
 export default class SensorGraph extends React.Component<SensorGraphProps, SensorGraphState> {
@@ -73,6 +76,19 @@ export default class SensorGraph extends React.Component<SensorGraphProps, Senso
         const sensorRange = sensorDefinition.maxReading - sensorDefinition.minReading,
               sensorPrecision = Format.getFixValue(sensorRange);
         return sensorPrecision;
+    }
+
+    handleRescale = (xRange:number[], yRange:number[]) => {
+        const { sensorSlot } = this.props,
+              { yMin, yMax } = this.state,
+              sensor = sensorSlot && sensorSlot.sensor,
+              sensorUnit = sensor && sensor.valueUnit;
+        if (yMin !== yRange[0] || yMax !== yRange[1]) {
+            this.setState({ sensorUnit, yMin: yRange[0], yMax: yRange[1] });
+        }
+        if (this.props.onGraphZoom) {
+            this.props.onGraphZoom(xRange[0], xRange[1]);
+        }
     }
     
     zeroSensor = () => {
@@ -166,22 +182,45 @@ export default class SensorGraph extends React.Component<SensorGraphProps, Senso
     }
     
     componentWillReceiveProps(nextProps:SensorGraphProps) {
-        if(!this.props.dataReset && nextProps.dataReset) {
+        const { dataReset } = this.props;
+        if(!dataReset && nextProps.dataReset) {
             this.lastDataIndex = 0;
+
+            // if sensor type changes, revert to default axis range for sensor
+            const { sensorUnit } = this.state,
+                  nextSensor = nextProps.sensorSlot && nextProps.sensorSlot.sensor,
+                  nextSensorUnit = nextSensor && nextSensor.valueUnit;
+            if (sensorUnit !== nextSensorUnit) {
+                this.setState({ yMin: null, yMax: null });
+            }
         }
+    }
+
+    xLabel() {
+        const { isLastGraph, timeUnit } = this.props;
+        return isLastGraph ? `Time (${timeUnit})` : "";
+    }
+
+    yLabel() {
+        const { sensorSlot } = this.props,
+        // label the data (if any) or the current sensor (if no data)
+        sensor = sensorSlot.dataSensor || sensorSlot.sensor,
+        sensorDefinition = sensor && sensor.definition,
+        measurementName = (sensorDefinition && sensorDefinition.measurementName) || "",
+        valueUnit = sensor.valueUnit || "";
+        return measurementName
+                ? `${measurementName} (${valueUnit})`
+                : "Sensor Reading (-)";
     }
     
     renderGraph(graphWidth:number|null) {
         const { sensor } = this.props.sensorSlot,
+              { yMin, yMax } = this.state,
               sensorDefinition = sensor && sensor.definition,
               minReading = sensorDefinition && sensorDefinition.minReading,
               maxReading = sensorDefinition && sensorDefinition.maxReading,
-              measurementName = (sensorDefinition && sensorDefinition.measurementName) || "",
-              valueUnit = sensor.valueUnit || "",
-              xLabel = this.props.isLastGraph ? `Time (${this.props.timeUnit})` : "",
-              yLabel = measurementName
-                        ? `${measurementName} (${valueUnit})`
-                        : "Sensor Reading (-)";
+              plotYMin = yMin != null ? yMin : (minReading != null ? minReading : 0),
+              plotYMax = yMax != null ? yMax : (maxReading != null ? maxReading : 10);
         return (
             <div className="sensor-graph">
               <Graph 
@@ -189,14 +228,14 @@ export default class SensorGraph extends React.Component<SensorGraphProps, Senso
                 width={graphWidth}
                 height={this.props.height}
                 data={this.props.sensorSlot.sensorData}
-                onZoom={this.props.onGraphZoom}
+                onRescale={this.handleRescale}
                 xMin={this.props.xStart}
                 xMax={this.props.xEnd}
-                yMin={minReading != null ? minReading : 0}
-                yMax={maxReading != null ? maxReading : 10}
+                yMin={plotYMin}
+                yMax={plotYMax}
                 valuePrecision={this.sensorPrecision()}
-                xLabel={xLabel}
-                yLabel={yLabel} />
+                xLabel={this.xLabel()}
+                yLabel={this.yLabel()} />
             </div>
         );
     }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,43 +1,17 @@
+import { precisionFixed } from "d3-format";
+
 export class Format {
     
-    static getPrecision(range:number):number {
-        var stepSize = range / 4000;
-        var precision;
-        var fixVal = 0;
-        if(stepSize < 1) {
-            fixVal = Math.round(-Math.log10(stepSize))+2;
-        }
-        
-        precision = Math.log10(Math.round(stepSize)) + fixVal;
-        precision = Math.max(1, Math.min(precision, 21));
-        
-        return precision;
-    }
-    
     static getFixValue(range:number):number {
-        var stepSize = range / 4000;
-        var precision;
-        if(stepSize < 1) {
-            precision = Math.round(-Math.log10(stepSize));
-        } else {
-            precision = 0;  //Math.round(Math.log10(Math.round(stepSize))) + 1;
-        }
-        precision = Math.max(0, Math.min(precision, 21));
-        return precision;
+        return precisionFixed(range / 2048);
     }
     
-    static getAxisFix(range:number):number {
-        var stepSize = range / 10;
-        var precision;
-        if(stepSize < 1) {
-            precision = Math.round(-Math.log10(stepSize) + 0.5);
-        } else if(stepSize < 5) {
-            precision = Math.round(-Math.log10(stepSize));
-        } else {
-            precision = 0;
-        }
-        precision = Math.max(0, Math.min(precision, 21));
-        return precision;
+    static getAxisFix(axis:string, range:number, pix:number|null):number {
+        // number of ticks depends on axis and width/height
+        // magic numbers determined empirically from dygraphs behavior
+        var step = axis === 'x' ? (pix && pix > 1460 ? range / 20 : range / 10)
+                                : (pix && pix < 640 ? range / 20 : range / 10);
+        return precisionFixed(step);
     }
     
     static formatFixedValue(value:number, fix:number, unit:string="", shorthand:boolean=false):string {


### PR DESCRIPTION
- Use `d3-format` for determining tick precision [#151271053]
- Use appropriate precision for sensor readings, legend view, etc.
- Rescale graph scales Y axis correctly
  - graph remembers new axis scales until changed
  - Y axis scales go back to default range on sensor change
- Y axis label no longer overlaps tick labels
- Y axis label reflects collected data, even after sensor change
