### PR TITLE
Reload SensorConnector application when necessary/appropriate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,20 +5,40 @@
   "requires": true,
   "dependencies": {
     "@concord-consortium/sensor-connector-interface": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/sensor-connector-interface/-/sensor-connector-interface-0.1.1.tgz",
-      "integrity": "sha1-snbxJuUC1N7ikqdxE7+eZrbcuaM=",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/sensor-connector-interface/-/sensor-connector-interface-0.1.3.tgz",
+      "integrity": "sha512-3MQLo3yw6sL6Rx727not9WNkVwlvk1RlOFmlopvzKvDLzJaE7VOexqo0TBAhhkt0sDdudqGUtxlhyGXI+Yp5wQ==",
       "requires": {
-        "eventemitter2": "4.1.2",
-        "lodash": "3.10.1",
-        "machina": "1.1.2",
-        "rsvp": "3.6.2"
+        "es6-promise": "4.2.4",
+        "eventemitter2": "5.0.1",
+        "lodash": "4.17.5",
+        "machina": "2.0.2"
       },
       "dependencies": {
+        "eventemitter2": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
+          "integrity": "sha1-YZegldX7a1folC9v1+qtY6CclFI="
+        },
         "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+        },
+        "machina": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/machina/-/machina-2.0.2.tgz",
+          "integrity": "sha512-9U9g4eQjQ2JARX7h/051r65EQEfFfpPxoSjVmUMJG6gnfjVjM+rjwVLoq7Z9NovjYm7AR3oTWWPtHVlgeSZzYw==",
+          "requires": {
+            "lodash": "3.10.1"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "3.10.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+            }
+          }
         }
       }
     },
@@ -1252,6 +1272,11 @@
         "event-emitter": "0.3.5"
       }
     },
+    "es6-promise": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+    },
     "es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
@@ -1369,11 +1394,6 @@
         "stream-combiner": "0.0.4",
         "through": "2.3.8"
       }
-    },
-    "eventemitter2": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-4.1.2.tgz",
-      "integrity": "sha1-DhqEd6+CGm7zmVsxG/dMI6UkfxU="
     },
     "events": {
       "version": "1.1.1",
@@ -3290,21 +3310,6 @@
         "yallist": "2.1.2"
       }
     },
-    "machina": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/machina/-/machina-1.1.2.tgz",
-      "integrity": "sha1-GMq+pfqet8AyQI6zCf6yr3qDckc=",
-      "requires": {
-        "lodash": "3.10.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-        }
-      }
-    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -4284,11 +4289,6 @@
         "hash-base": "2.0.2",
         "inherits": "2.0.3"
       }
-    },
-    "rsvp": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
     },
     "safe-buffer": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/concord-consortium/sensor-interactive#readme",
   "dependencies": {
-    "@concord-consortium/sensor-connector-interface": "^0.1.0",
+    "@concord-consortium/sensor-connector-interface": "^0.1.3",
     "d3-format": "^1.2.0",
     "dygraphs": "^2.0.0",
     "iframe-phone": "^1.2.0",

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import ReactModal from "react-modal";
 import { Sensor } from "../models/sensor";
 import { SensorSlot } from "../models/sensor-slot";
-import { SensorConfiguration } from "../models/sensor-configuration";
+import { SensorConfiguration, gNullSensorConfig } from "../models/sensor-configuration";
 import { ISensorConfigColumnInfo } from "../models/sensor-connector-interface";
 import GraphsPanel from "./graphs-panel";
 import { ControlPanel } from "./control-panel";
@@ -140,6 +140,7 @@ export class App extends React.Component<AppProps, AppState> {
         sensorManager.addListener('onSensorConnect', this.onSensorConnect);
         sensorManager.addListener('onSensorData', this.onSensorData);
         sensorManager.addListener('onSensorStatus', this.onSensorStatus);
+        sensorManager.addListener('onCommunicationError', this.onCommunicationError);
         this.props.sensorManager.startPolling();
 
         this.onTimeSelect = this.onTimeSelect.bind(this);
@@ -191,7 +192,7 @@ export class App extends React.Component<AppProps, AppState> {
             const timeUnit = sensorConfig.timeUnit || "",
                   dataColumns = sensorConfig.dataColumns;
 
-            sensorSlots = matchSensorsToDataColumns(sensorSlots, dataColumns);
+            sensorSlots = matchSensorsToDataColumns(sensorSlots, dataColumns || null);
 
             this.setState({ sensorConfig, sensorSlots, timeUnit });
         }
@@ -310,6 +311,11 @@ export class App extends React.Component<AppProps, AppState> {
         });
 
         this.setState({ sensorConfig, sensorSlots: this.state.sensorSlots });
+    }
+
+    onCommunicationError = () => {
+        this.onSensorConnect(gNullSensorConfig);
+        this.setState({ statusMessage: "SensorConnector not responding" });
     }
 
     hasData() {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -106,6 +106,7 @@ export class App extends React.Component<AppProps, AppState> {
     private codap:Codap;
     private selectionRange:{start:number,end:number|undefined} = {start:0,end:undefined};
     private disableWarning:boolean = false;
+    private isReloading:boolean = false;
 
     constructor(props: AppProps) {
         super(props);
@@ -171,6 +172,8 @@ export class App extends React.Component<AppProps, AppState> {
     onSensorConnect(sensorConfig:SensorConfiguration) {
         const interfaceType = sensorConfig.interface;
         let sensorSlots = this.state.sensorSlots;
+
+        if (this.isReloading) { return; }
 
         if(!sensorConfig.hasInterface) {
             sensorSlots = matchSensorsToDataColumns(sensorSlots, null);
@@ -440,7 +443,12 @@ export class App extends React.Component<AppProps, AppState> {
     }
 
     reload() {
-        location.reload();
+        this.isReloading = true;
+        this.setState({ statusMessage: "Reloading SensorConnector..."});
+        this.props.sensorManager.requestExit();
+        // pause before attempting to reload page
+        const RELOAD_PAGE_DELAY_SEC = 3;
+        setTimeout(() => location.reload(), RELOAD_PAGE_DELAY_SEC * 1000);
     }
 
     componentDidUpdate(prevProps:AppProps, prevState:AppState) {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -101,8 +101,6 @@ function isConnectableSensorManager(manager: ConnectableSensorManager | any) :
 export class App extends React.Component<AppProps, AppState> {
 
     private messages:IStringMap;
-    private lastDataIndex:number;
-    private lastTime:number;
     private codap:Codap;
     private selectionRange:{start:number,end:number|undefined} = {start:0,end:undefined};
     private disableWarning:boolean = false;
@@ -230,7 +228,6 @@ export class App extends React.Component<AppProps, AppState> {
 
     stopSensor() {
         this.props.sensorManager.requestStop();
-        this.lastTime = 0;
     }
 
     onSensorCollectionStopped() {
@@ -363,7 +360,6 @@ export class App extends React.Component<AppProps, AppState> {
             dataReset:true,
             dataChanged:false
         });
-        this.lastDataIndex = 0;
     }
 
     onTimeSelect(newTime:number) {

--- a/src/components/control-panel.tsx
+++ b/src/components/control-panel.tsx
@@ -3,6 +3,7 @@ import Button from "./smart-highlight-button";
 import Select from "./smart-highlight-select";
 
 interface IControlPanelProps {
+  isConnectorAwake:boolean;
   interfaceType:string;
   collecting:boolean;
   hasData:boolean;
@@ -12,6 +13,7 @@ interface IControlPanelProps {
   durationOptions:number[];
   embedInCodapUrl:string|null;
   onDurationChange:(duration:number) => void;
+  onStartConnecting: () => void;
   onStartCollecting: () => void;
   onStopCollecting: () => void;
   onNewRun: () => void;
@@ -20,7 +22,9 @@ interface IControlPanelProps {
 }
 
 export const ControlPanel: React.SFC<IControlPanelProps> = (props) => {
-  const disableStartCollecting = !props.interfaceType ||props.collecting || props.hasData,
+  const disableStartConnecting = props.isConnectorAwake,
+        disableStartCollecting = (props.isConnectorAwake && !props.interfaceType) ||
+                                    props.collecting || props.hasData,
         disableStopCollecting = !props.collecting,
         disableSendData = !(props.hasData && props.dataChanged) || props.collecting,
         disableNewData = !props.hasData || props.collecting,
@@ -28,7 +32,19 @@ export const ControlPanel: React.SFC<IControlPanelProps> = (props) => {
                             const dStr = String(d),
                                   dFormatted = d.toFixed(1) + props.durationUnit;
                             return <option key={dStr} value={dStr}>{dFormatted}</option>;
-                          });
+                          }),
+        startConnectingButton = (
+          <Button className="startConnection control-panel-button"
+                  onClick={props.onStartConnecting} disabled={disableStartConnecting}>
+            Connect
+          </Button>
+        ),
+        startCollectingButton = (
+          <Button className="startSensor control-panel-button"
+                  onClick={props.onStartCollecting} disabled={disableStartCollecting}>
+            Start
+          </Button>
+        );
   
   function handleDurationChange(evt:React.FormEvent<HTMLSelectElement>) {
     if (props.onDurationChange)
@@ -50,10 +66,7 @@ export const ControlPanel: React.SFC<IControlPanelProps> = (props) => {
               onChange={handleDurationChange} value={String(props.duration)}>
         {[durationOptions]}
       </Select>
-      <Button className="startSensor control-panel-button"
-              onClick={props.onStartCollecting} disabled={disableStartCollecting}>
-        Start
-      </Button>
+      {props.isConnectorAwake ? startCollectingButton : startConnectingButton}
       <Button className="stopSensor control-panel-button"
               onClick={props.onStopCollecting} disabled={disableStopCollecting}>
         Stop

--- a/src/components/control-panel.tsx
+++ b/src/components/control-panel.tsx
@@ -70,7 +70,7 @@ export const ControlPanel: React.SFC<IControlPanelProps> = (props) => {
         <div>
           <a onClick={props.onReloadPage}
               className="reload-page-button"
-              title="Reload page">
+              title="Reload All">
               <i className="fa fa-repeat fa-2x"></i>
           </a>
         </div>

--- a/src/components/graph-side-panel.tsx
+++ b/src/components/graph-side-panel.tsx
@@ -2,14 +2,14 @@ import * as React from "react";
 import { Format } from "../utils/format";
 import { SensorSlot } from "../models/sensor-slot";
 import { SensorDefinitions } from "../models/sensor-definitions";
-import { ISensorConfigColumnInfo } from "../models/sensor-connector-interface";
+import { SensorConfigColumnInfo } from "@concord-consortium/sensor-connector-interface";
 import Button from "./smart-highlight-button";
 import Select from "./smart-highlight-select";
 
 interface IGraphSidePanelProps {
   width?:number;
   sensorSlot:SensorSlot;
-  sensorColumns:ISensorConfigColumnInfo[];
+  sensorColumns:SensorConfigColumnInfo[];
   sensorPrecision:number;
   onSensorSelect?:(sensorIndex:number, columnID:string) => void;
   onZeroSensor?:() => void;
@@ -43,11 +43,11 @@ export const GraphSidePanel: React.SFC<IGraphSidePanelProps> = (props) => {
     return (sensorUnitStr) ? `${reading} ${sensorUnitStr}` : reading;
   };
 
-  const sensorSelectOptions = (sensorColumns:ISensorConfigColumnInfo[]) => {
+  const sensorSelectOptions = (sensorColumns:SensorConfigColumnInfo[]) => {
     const columns = sensorColumns || [];
     // if no sensor slot or not enough sensors, there are no options
     if ((sensorSlot.slotIndex == null) || (sensorSlot.slotIndex >= columns.length)) return null;
-    return columns.map((column:ISensorConfigColumnInfo, index:number) => {
+    return columns.map((column:SensorConfigColumnInfo, index:number) => {
       const units = column && column.units,
             columnID = column && column.id,
             sensorDef = units && SensorDefinitions[units],

--- a/src/components/sensor-graph.tsx
+++ b/src/components/sensor-graph.tsx
@@ -3,7 +3,7 @@ import { Sensor } from "../models/sensor";
 import { SensorSlot } from "../models/sensor-slot";
 import { Graph } from "./graph";
 import { GraphSidePanel } from "./graph-side-panel";
-import { ISensorConfigColumnInfo } from "../models/sensor-connector-interface";
+import { SensorConfigColumnInfo } from "@concord-consortium/sensor-connector-interface";
 import { Format } from "../utils/format";
 
 const kSidePanelWidth = 200;
@@ -11,7 +11,7 @@ const kSidePanelWidth = 200;
 interface SensorGraphProps {
     width:number|null;
     height:number|null;
-    sensorColumns:ISensorConfigColumnInfo[];
+    sensorColumns:SensorConfigColumnInfo[];
     sensorSlot:SensorSlot;
     title:string;
     onGraphZoom:(xStart:number, xEnd:number) => void;

--- a/src/models/fake-sensor-manager.ts
+++ b/src/models/fake-sensor-manager.ts
@@ -1,12 +1,12 @@
 import { SensorConfiguration } from "./sensor-configuration";
 import { SensorManager } from "./sensor-manager";
-import { ISensorConfig } from "./sensor-connector-interface";
+import { SensorConfig } from "@concord-consortium/sensor-connector-interface";
 
 export class FakeSensorManager extends SensorManager {
     supportsDualCollection = true;
     
     private sensorConfig: SensorConfiguration;
-    private internalConfig: ISensorConfig;
+    private internalConfig: SensorConfig;
     private hasData: boolean = false;
     private interval: any;
 

--- a/src/models/sensor-configuration.ts
+++ b/src/models/sensor-configuration.ts
@@ -6,9 +6,9 @@ export class SensorConfiguration {
   // We'd like to abstract the SensorConfiguration from the SensorConnector
   // so instead of accessing the ISensorConfig directly, please add accessor methods
   // to make it easier to do this abstraction in the future
-  private config:ISensorConfig;
+  private config:ISensorConfig | null;
 
-  constructor(config:ISensorConfig) {
+  constructor(config:ISensorConfig | null) {
     this.config = config;
   }
 
@@ -23,6 +23,7 @@ export class SensorConfiguration {
   // retrieve ID of the current dataset
   get setID() {
     // current setID is the largest numeric setID
+    if (!this.config) { return; }
     const keys = Object.keys(this.config.sets),
           numKeys = keys.map((id) => Number(id));
     return Math.max.apply(Math, numKeys);
@@ -30,24 +31,25 @@ export class SensorConfiguration {
 
   // retrieve columns for current dataset
   get columns() {
+    if (!this.config) { return; }
     const setID = this.setID,
           colIDs = this.config.sets[setID].colIDs;
     // setID -> set -> colIDs -> columns
-    return colIDs.map((colID) => this.config.columns[colID]);
+    return colIDs.map((colID) => (this.config as ISensorConfig).columns[colID]);
   }
 
   getColumnByID(columnID?:string) {
-    return columnID != null ? this.config.columns[columnID] : null;
+    return this.config && (columnID != null) ? this.config.columns[columnID] : undefined;
   }
 
   // retrieve "Time" column for current dataset
   get timeColumn() {
-    return find(this.columns, (col) => col.name === "Time");
+    return find(this.columns, (col) => (col != null) && (col.name === "Time"));
   }
 
   // retrieve non-"Time" columns for current dataset
   get dataColumns() {
-    return this.columns.filter((col) => col.name !== "Time");
+    return this.columns && this.columns.filter((col) => (col != null) && (col.name !== "Time"));
   }
 
   get timeUnit() {
@@ -55,3 +57,5 @@ export class SensorConfiguration {
     return timeColumn && timeColumn.units;
   }
 }
+
+export const gNullSensorConfig = new SensorConfiguration(null);

--- a/src/models/sensor-configuration.ts
+++ b/src/models/sensor-configuration.ts
@@ -1,14 +1,14 @@
 import { find } from "lodash";
 
-import { ISensorConfig } from "./sensor-connector-interface";
+import { SensorConfig } from "@concord-consortium/sensor-connector-interface";
 
 export class SensorConfiguration {
   // We'd like to abstract the SensorConfiguration from the SensorConnector
   // so instead of accessing the ISensorConfig directly, please add accessor methods
   // to make it easier to do this abstraction in the future
-  private config:ISensorConfig | null;
+  private config:SensorConfig | null;
 
-  constructor(config:ISensorConfig | null) {
+  constructor(config:SensorConfig | null) {
     this.config = config;
   }
 
@@ -35,7 +35,7 @@ export class SensorConfiguration {
     const setID = this.setID,
           colIDs = this.config.sets[setID].colIDs;
     // setID -> set -> colIDs -> columns
-    return colIDs.map((colID) => (this.config as ISensorConfig).columns[colID]);
+    return colIDs.map((colID) => (this.config as SensorConfig).columns[colID]);
   }
 
   getColumnByID(columnID?:string) {

--- a/src/models/sensor-connector-manager.ts
+++ b/src/models/sensor-connector-manager.ts
@@ -35,6 +35,9 @@ export class SensorConnectorManager extends SensorManager {
       this.sensorConnector.on("collectionStopped", this.handleSensorCollectionStopped);
 
       this.sensorConnector.on("statusReceived", this.handleSensorStatus);
+
+      this.sensorConnector.on("statusErrored", this.handleCommunicationError);
+      this.sensorConnector.on("launchTimedOut", this.handleCommunicationError);
     }
 
     startPolling() {
@@ -65,6 +68,10 @@ export class SensorConnectorManager extends SensorManager {
 
     requestExit() {
       this.sensorConnector.requestExit();
+    }
+    
+    handleCommunicationError = () => {
+        this.onCommunicationError();
     }
     
     handleSensorConnect = () => {

--- a/src/models/sensor-connector-manager.ts
+++ b/src/models/sensor-connector-manager.ts
@@ -6,6 +6,7 @@ import { IStatusReceivedTuple, ISensorConfigColumnInfo, ISensorConnectorDataset 
 import { SensorManager, NewSensorData } from "./sensor-manager";
 
 const SENSOR_IP = "http://127.0.0.1:11180";
+const DELAY_AFTER_WAKE = 1000;
 
 interface ColumnInfo {
   lastDataIndex: number;
@@ -50,7 +51,12 @@ export class SensorConnectorManager extends SensorManager {
     }
 
     requestStart() {
-      this.sensorConnector.requestStart();
+      if (this.sensorConnector.wake()) {
+        this.sensorConnector.requestStart();
+      }
+      else {
+        setTimeout(() => this.sensorConnector.requestStart(), DELAY_AFTER_WAKE);
+      }
     }
 
     requestStop() {

--- a/src/models/sensor-connector-manager.ts
+++ b/src/models/sensor-connector-manager.ts
@@ -1,4 +1,6 @@
 import SensorConnectorInterface from "@concord-consortium/sensor-connector-interface";
+// must use the following form when using npm link to develop/debug locally
+//import * as SensorConnectorInterface from "@concord-consortium/sensor-connector-interface";
 import { SensorConfiguration } from "./sensor-configuration";
 import { IStatusReceivedTuple, ISensorConfigColumnInfo, ISensorConnectorDataset } from "./sensor-connector-interface";
 import { SensorManager, NewSensorData } from "./sensor-manager";
@@ -55,6 +57,10 @@ export class SensorConnectorManager extends SensorManager {
       this.sensorConnector.requestStop();
     }
 
+    requestExit() {
+      this.sensorConnector.requestExit();
+    }
+    
     handleSensorConnect = () => {
         const statusReceived:IStatusReceivedTuple = this.sensorConnector.stateMachine.currentActionArgs,
             config = statusReceived[1];

--- a/src/models/sensor-definitions.ts
+++ b/src/models/sensor-definitions.ts
@@ -1,8 +1,6 @@
 // from concord-consortium/lab
 
-/* tslint:disable:max-line-length */
-
-import { ISensorDefinition } from "./sensor-connector-interface";
+import { SensorDefinition } from "@concord-consortium/sensor-connector-interface";
 
 export interface IStringMap {
   [key:string]: string;
@@ -11,6 +9,8 @@ export interface IStringMap {
 export interface ISensorStrings {
   [key:string]: string|IStringMap;
 }
+
+/* tslint:disable:max-line-length */
 
 export const SensorStrings:ISensorStrings = {
     "select_sensor": "Select Sensor",
@@ -165,7 +165,7 @@ export class i18n { // tslint:disable-line:class-name
 }
 
 export interface ISensorDefinitions {
-  [key:string]: ISensorDefinition;
+  [key:string]: SensorDefinition;
 }
 
 export const SensorDefinitions:ISensorDefinitions = {

--- a/src/models/sensor-manager.ts
+++ b/src/models/sensor-manager.ts
@@ -30,6 +30,10 @@ export abstract class SensorManager {
   abstract requestStart() : void;
   abstract requestStop() : void;
 
+  requestExit() : void {
+    // no base class implementation - derived classes should override if appropriate
+    return;
+  }
 
   private readonly listeners : Map<string, Set<any>> = new Map();
 

--- a/src/models/sensor-manager.ts
+++ b/src/models/sensor-manager.ts
@@ -30,9 +30,23 @@ export abstract class SensorManager {
   abstract requestStart() : void;
   abstract requestStop() : void;
 
-  requestExit() : void {
-    // no base class implementation - derived classes should override if appropriate
+  isAwake() : boolean {
+    return true;
+  }
+
+  // derived classes should override if they have an appropriate implementation,
+  // e.g. quit SensorConnector application, enter a low-power mode, etc.
+  requestSleep() : void {
+    // no base class implementation
     return;
+  }
+
+  // derived classes should override if they have an appropriate implementation,
+  // e.g. open SensorConnector application, exit a low-power mode, etc.
+  // returns true if already awake, false if launch/wake required.
+  requestWake() : boolean {
+    // true indicates already awake
+    return true;
   }
 
   private readonly listeners : Map<string, Set<any>> = new Map();

--- a/src/models/sensor-manager.ts
+++ b/src/models/sensor-manager.ts
@@ -80,4 +80,8 @@ export abstract class SensorManager {
   protected onSensorStatus(sensorConfig:SensorConfiguration) {
     this.notifyListeners('onSensorStatus', sensorConfig);
   }
+
+  protected onCommunicationError() {
+    this.notifyListeners('onCommunicationError');
+  }
 }

--- a/src/models/sensor-tag-manager.ts
+++ b/src/models/sensor-tag-manager.ts
@@ -1,7 +1,7 @@
 import { SensorConfiguration } from "./sensor-configuration";
 import { SensorManager,
          NewSensorData, ConnectableSensorManager } from "./sensor-manager";
-import { ISensorConfig } from "./sensor-connector-interface";
+import { SensorConfig } from "@concord-consortium/sensor-connector-interface";
 import { cloneDeep } from "lodash";
 
 const tagIdentifier = 0xaa80;
@@ -109,7 +109,7 @@ export class SensorTagManager extends SensorManager implements ConnectableSensor
     supportsDualCollection = false;
 
     private sensorConfig: SensorConfiguration;
-    private internalConfig: ISensorConfig;
+    private internalConfig: SensorConfig;
     private hasData: boolean = false;
     private stopRequested: boolean = false;
     private device: any;

--- a/src/models/sensor.ts
+++ b/src/models/sensor.ts
@@ -1,4 +1,4 @@
-import { ISensorDefinition } from "./sensor-connector-interface";
+import { SensorDefinition } from "@concord-consortium/sensor-connector-interface";
 
 export class Sensor {
     columnID?:string;
@@ -8,7 +8,7 @@ export class Sensor {
     tareValue:number;
     timeUnit:string;
     valueUnit:string;
-    definition:ISensorDefinition;
+    definition:SensorDefinition;
 
     constructor() {
         this.tareValue = 0;

--- a/src/models/thermoscope-manager.ts
+++ b/src/models/thermoscope-manager.ts
@@ -1,7 +1,7 @@
 import { SensorConfiguration } from "./sensor-configuration";
 import { SensorManager,
          NewSensorData, ConnectableSensorManager } from "./sensor-manager";
-import { ISensorConfig } from "./sensor-connector-interface";
+import { SensorConfig } from "@concord-consortium/sensor-connector-interface";
 import { cloneDeep } from "lodash";
 
 interface ISensorAddrs {
@@ -57,7 +57,7 @@ export class ThermoscopeManager extends SensorManager implements ConnectableSens
     supportsDualCollection = true;
 
     private sensorConfig: SensorConfiguration;
-    private internalConfig: ISensorConfig;
+    private internalConfig: SensorConfig;
     private hasData: boolean = false;
     private stopRequested: boolean = false;
     private device: any;

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,3 +1,2 @@
-declare module '@concord-consortium/sensor-connector-interface';
 declare module 'react-modal';
 declare module 'react-sizeme';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
         "target": "es6",
         "strictNullChecks": true,
         "jsx": "react",
-        "allowJs": true
+        "allowJs": true,
+        "allowSyntheticDefaultImports": true
     },
     "include": [
         "./src/**/*"


### PR DESCRIPTION
Show message to user if SensorConnector application is not responding.

Reload button in lower right-hand corner of SensorInteractive interface sends a request to SensorConnector application to quit and then waits three seconds before reloading the browser page.

When SensorConnector application is not responding change "Start" button to a "Connect" button which attempts to relaunch the SensorConnector application. This is useful when the SensorConnector application quits after being idle.

Move TypeScript definitions for SensorConnectorInterface library into SensorConnectorInterface library itself.

Note that this requires that https://github.com/concord-consortium/sensor-connector-interface/pull/2 be published in an updated version of the SensorConnectorInterface module. There will probably be some additional version number changes as well. The functionality was tested locally with npm link.

@scytacki Travis build failure is due to lack of type definitions in the sensor-connector-interface library because they're in a separate PR. The updated sensor-connector-interface will need to be published to npm for this PR to build.