### PR TITLE
Bug fixes

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -10,7 +10,7 @@ import { Codap } from "../models/codap";
 import { IStringMap, SensorStrings, SensorDefinitions } from "../models/sensor-definitions";
 import { SensorManager, NewSensorData, ConnectableSensorManager } from "../models/sensor-manager";
 import SmartFocusHighlight from "../utils/smart-focus-highlight";
-import { find, pull } from "lodash";
+import { find, pull, sumBy } from "lodash";
 import Button from "./smart-highlight-button";
 
 
@@ -185,8 +185,10 @@ export class App extends React.Component<AppProps, AppState> {
     setStatusInterfaceConnected(interfaceType: string) {
         const connectMessage = this.messages["interface_connected"]
                                    .replace('__interface__', interfaceType || ""),
+              noSensorsMessage = this.connectedSensorCount() === 0
+                                    ? ` -- ${this.messages['no_sensors']}` : "",
               collectMessage = this.state.collecting ? ` -- ${this.messages['collecting_data']}` : "",
-              message = connectMessage + collectMessage;
+              message = connectMessage + (noSensorsMessage || collectMessage);
         this.setState({ statusMessage: message });
     }
 
@@ -374,6 +376,10 @@ export class App extends React.Component<AppProps, AppState> {
         if (!this.state.suppressNotRespondingModal) {
             this.setState({ notRespondingModal: true, suppressNotRespondingModal: true });
         }
+    }
+
+    connectedSensorCount() {
+        return sumBy(this.state.sensorSlots, (slot) => slot.isConnected ? 1 : 0);
     }
 
     hasData() {
@@ -657,6 +663,7 @@ export class App extends React.Component<AppProps, AppState> {
                 <ControlPanel
                     isConnectorAwake={this.props.sensorManager.isAwake()}
                     interfaceType={interfaceType}
+                    sensorCount={this.connectedSensorCount()}
                     collecting={this.state.collecting}
                     hasData={this.state.hasData}
                     dataChanged={this.state.dataChanged}

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -398,8 +398,8 @@ export class App extends React.Component<AppProps, AppState> {
     }
 
     sendData() {
-        const { sensorSlots } = this.state,
-              sendSecondSensorData = sensorSlots[1].hasData;
+        const { sensorSlots, secondGraph } = this.state,
+              sendSecondSensorData = secondGraph && sensorSlots[1].hasData;
         const dataSpecs = sensorSlots.map((slot, i) => {
             const sensor = slot.sensorForData,
                   name = sensor && sensor.definition.measurementName,

--- a/src/components/control-panel.tsx
+++ b/src/components/control-panel.tsx
@@ -5,6 +5,7 @@ import Select from "./smart-highlight-select";
 interface IControlPanelProps {
   isConnectorAwake:boolean;
   interfaceType:string;
+  sensorCount:number;
   collecting:boolean;
   hasData:boolean;
   dataChanged:boolean;
@@ -24,7 +25,7 @@ interface IControlPanelProps {
 export const ControlPanel: React.SFC<IControlPanelProps> = (props) => {
   const disableStartConnecting = props.isConnectorAwake,
         disableStartCollecting = (props.isConnectorAwake && !props.interfaceType) ||
-                                    props.collecting || props.hasData,
+                                  (props.sensorCount === 0) || props.collecting || props.hasData,
         disableStopCollecting = !props.collecting,
         disableSendData = !(props.hasData && props.dataChanged) || props.collecting,
         disableNewData = !props.hasData || props.collecting,


### PR DESCRIPTION
[#157431975] Only export second sensor data if requested by user
[#157413166] Disable `Collect` button when there are no sensors
- Add "no sensors" message to interface connection message when appropriate

@scytacki As far as I know now, this is the last set of bug-fixes expected for next week's classroom test.