### PR TITLE
Fix document load issues

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -179,6 +179,8 @@ export class App extends React.Component<AppProps, AppState> {
         this.codap = new Codap((initialState:any) => {
             // merge saved initial state into current state
             this.setState(initialState);
+            if (initialState && (initialState.runLength != null))
+                this.setXZoomState(initialState.runLength);
         });
     }
 

--- a/src/models/codap.ts
+++ b/src/models/codap.ts
@@ -81,17 +81,22 @@ export class Codap {
                 if (response.success) {
                     // request the last case
                     const caseCount = response.values;
-                    CodapInterface.sendRequest({
-                        action: 'get',
-                        resource: `${runsCollection}.caseByIndex[${caseCount-1}]`
-                    }, this.responseCallback)
-                    .then((response) => {
-                        // retrieve the run number from the last case
-                        if (response.success) {
-                            const theCase = response.values['case'];
-                            this.state.runNumber = theCase.values.Run;
-                        }
-                    }, this.responseCallback);
+                    if (caseCount > 0) {
+                        CodapInterface.sendRequest({
+                            action: 'get',
+                            resource: `${runsCollection}.caseByIndex[${caseCount-1}]`
+                        }, this.responseCallback)
+                        .then((response) => {
+                            // retrieve the run number from the last case
+                            if (response.success) {
+                                const theCase = response.values['case'];
+                                this.state.runNumber = theCase.values.Run;
+                            }
+                        }, this.responseCallback);
+                    }
+                    else {
+                        this.state.runNumber = 0;
+                    }
                 }
             });
         });


### PR DESCRIPTION
Reset `Run` number when loading document with empty collection [#159858442]
Reset X scale of graph to match restored `runLength`

Note: Depends on PR #32, which should be merged first and then this PR could be rebased to master.

Pair-programmed with @mklewandowski .