### PR TITLE
Tech Debt: Remove unused `onStopCollection` props

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -667,7 +667,6 @@ export class App extends React.Component<AppProps, AppState> {
                         secondGraph={this.state.secondGraph}
                         onGraphZoom={this.onGraphZoom}
                         onSensorSelect={this.handleSensorSelect}
-                        onStopCollection={this.stopSensor}
                         xStart={this.state.xStart}
                         xEnd={this.state.xEnd}
                         timeUnit={this.state.timeUnit}

--- a/src/components/graphs-panel.tsx
+++ b/src/components/graphs-panel.tsx
@@ -16,7 +16,6 @@ interface IGraphsPanelProps {
   secondGraph:boolean;
   onGraphZoom:(xStart:number, xEnd:number) => void;
   onSensorSelect:(sensorIndex:number, columnID:string) => void;
-  onStopCollection:() => void;
   xStart:number;
   xEnd:number;
   timeUnit:string;
@@ -51,7 +50,6 @@ const GraphsPanelImp: React.SFC<IGraphsPanelProps> = (props) => {
                         isLastGraph={isLastGraph}
                         onGraphZoom={props.onGraphZoom}
                         onSensorSelect={props.onSensorSelect}
-                        onStopCollection={props.onStopCollection}
                         xStart={props.xStart}
                         xEnd={props.xEnd}
                         timeUnit={props.timeUnit}

--- a/src/components/sensor-graph.tsx
+++ b/src/components/sensor-graph.tsx
@@ -16,7 +16,6 @@ interface SensorGraphProps {
     title:string;
     onGraphZoom:(xStart:number, xEnd:number) => void;
     onSensorSelect:(sensorIndex:number, columnID:string) => void;
-    onStopCollection:() => void;
     collecting:boolean;
     hasData:boolean;
     dataReset:boolean;


### PR DESCRIPTION
These were left over from a time when graphs were able to control data collection