### PR TITLE
Allow dataset data interactives to be reorganized.

### DIFF
--- a/src/models/codap.ts
+++ b/src/models/codap.ts
@@ -63,7 +63,8 @@ export class Codap {
             name: this.dataSetName,
             title: this.dataSetTitle,
             dimensions: {width: 800, height: 490},
-            version: '0.1'
+            version: '0.1',
+            preventDataContextReorg: false
         }, this.responseCallback).then((iResult) => {
             // get interactive state so we can save the data set index.
             this.state = CodapInterface.getInteractiveState();

--- a/src/public/assets/js/CodapInterface.js
+++ b/src/public/assets/js/CodapInterface.js
@@ -244,7 +244,8 @@
           name: iConfig.name,
           title: iConfig.title,
           version: iConfig.version,
-          preventBringToFront: iConfig.preventBringToFront
+          preventBringToFront: iConfig.preventBringToFront,
+          preventDataContextReorg: iConfig.preventDataContextReorg
         };
         var updateFrameReq = {
           action: 'update',


### PR DESCRIPTION
Allow dataset data interactives to be reorganized. Set preventDataContextReorg=false when setting up the interactiveFrame object.
[#160958189]