### PR TITLE
Add support for Go Direct gyro/angular velocity channels

### DIFF
--- a/src/models/sensor-definitions.ts
+++ b/src/models/sensor-definitions.ts
@@ -650,7 +650,7 @@ export const SensorDefinitions:ISensorDefinitions = {
     "measurementName": i18n.t("sensor.measurements.angular_velocity"),
     "measurementType": "angular velocity",
     "tareable": false,
-    "minReading": -100.0,
-    "maxReading": 100.0
+    "minReading": -35.0,
+    "maxReading": 35.0
   }
 };

--- a/src/models/sensor-definitions.ts
+++ b/src/models/sensor-definitions.ts
@@ -644,7 +644,7 @@ export const SensorDefinitions:ISensorDefinitions = {
     "tareable": true,
     "minReading": 0.0,
     "maxReading": 50.0
-  }
+  },
   "rad/s": {
     "sensorName": i18n.t("sensor.names.angularvelocity"),
     "measurementName": i18n.t("sensor.measurements.angular_velocity"),

--- a/src/models/sensor-definitions.ts
+++ b/src/models/sensor-definitions.ts
@@ -106,7 +106,8 @@ export const SensorStrings:ISensorStrings = {
       "volume": "Volume",
       "pH": "pH",
       "acidity": "Acidity",
-      "O2_concentration": "O₂ Concentration"
+      "O2_concentration": "O₂ Concentration",
+      "angular_velocity": "Angular Velocity"
     },
     "names": {
       "sensor": "sensor",
@@ -153,7 +154,8 @@ export const SensorStrings:ISensorStrings = {
       "labQuestForce": "LabQuest Force Sensor",
       "labQuestPH": "LabQuest pH Sensor",
       "labQuestCO2": "LabQuest CO₂ sensor",
-      "labQuestO2": "LabQuest O₂ sensor"
+      "labQuestO2": "LabQuest O₂ sensor",
+      "angularvelocity": "Angular Velocity"
     }
 };
 
@@ -642,5 +644,13 @@ export const SensorDefinitions:ISensorDefinitions = {
     "tareable": true,
     "minReading": 0.0,
     "maxReading": 50.0
+  }
+  "rad/s": {
+    "sensorName": i18n.t("sensor.names.angularvelocity"),
+    "measurementName": i18n.t("sensor.measurements.angular_velocity"),
+    "measurementType": "angular velocity",
+    "tareable": false,
+    "minReading": -100.0,
+    "maxReading": 100.0
   }
 };


### PR DESCRIPTION
Expand sensor definitions to include support for Go Direct gyro/angualr velocity channels.  The Go Direct force and acceleration sensor includes 3 gyro channels which were previously hidden in sensor-interactive because they were not recognized as a valid sensor type. 