### PR TITLE
Go Direct Sensor Bluetooth implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,6 +115,11 @@
       "integrity": "sha512-C+BgVBBGY9c6ixcc5PsKAmGaCy3bswZ5zx/AWIAik9dgFuBkFsXBA3ze69jJi05xdZQ99QkfBSVIX6zl+6Tmww==",
       "dev": true
     },
+    "@vernier/godirect": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@vernier/godirect/-/godirect-1.4.3.tgz",
+      "integrity": "sha512-mfWUs40m+KctonoJ+Io/0sTWCV5lI0jZAUDFfQNVnONZxdAgKKhGZE8UxzMqu1pCLx4vaBPtWdwXfLtshusCnQ=="
+    },
     "@webassemblyjs/ast": {
       "version": "1.7.11",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.11.tgz",
@@ -1255,12 +1260,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1275,17 +1282,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -1402,7 +1412,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -1414,6 +1425,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -1428,6 +1440,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -1435,12 +1448,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -1459,6 +1474,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -1539,7 +1555,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -1551,6 +1568,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -1672,6 +1690,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "homepage": "https://github.com/concord-consortium/sensor-interactive#readme",
   "dependencies": {
     "@concord-consortium/sensor-connector-interface": "^0.1.3",
+    "@vernier/godirect": "^1.4.3",
     "d3-format": "^1.3.2",
     "dygraphs": "^2.1.0",
     "iframe-phone": "^1.2.0",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2,15 +2,11 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as ReactModal from "react-modal";
 import { App } from "./components/app";
-import { SensorConnectorManager } from "./models/sensor-connector-manager";
-
-let sensorManager = new SensorConnectorManager();
 
 const appElt = document.getElementById("app");
 ReactModal.setAppElement(appElt);
 
 ReactDOM.render(
-    <App
-      sensorManager={sensorManager}/>,
+    <App/>,
     appElt
 );

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -307,7 +307,15 @@ export class App extends React.Component<AppProps, AppState> {
         const wiredConnected = this.state.sensorManager instanceof SensorConnectorManager;
         if (wiredConnected) {
             //TODO: disconnect sensor connector manager
-            console.log("disconnect wired");
+            if (this.state.sensorManager instanceof SensorConnectorManager) {
+                this.state.sensorManager.removeListeners();
+            }
+            this.removeSensorManagerListeners();
+            this.setState({
+                sensorManager: null,
+                sensorConfig: null,
+                statusMessage: this.messages["no_sensors"]
+            });
         } else {
             const sensorManager = new SensorConnectorManager();
             this.setState({ sensorManager }, () => {
@@ -329,10 +337,13 @@ export class App extends React.Component<AppProps, AppState> {
     }
 
     disconnectWirelessDevice = () => {
+        //to do, clear config and then call onSensorStatus to update sensorSlots
         this.disconnectFromDevice();
         this.removeSensorManagerListeners();
         this.setState({
-            sensorManager: null
+            sensorManager: null,
+            sensorConfig: null,
+            statusMessage: this.messages["no_sensors"]
         });
     }
 

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -691,8 +691,8 @@ export class App extends React.Component<AppProps, AppState> {
             sensorManager.requestSleep();
             // pause before attempting to reload SensorConnector
             setTimeout(() => {
-                if (sensorManager) {
-                    sensorManager.requestWake();
+                if (this.state.sensorManager) {
+                    this.state.sensorManager.requestWake();
                 }
             }, SLEEP_WAKE_DELAY_SEC * 1000);
         }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -309,12 +309,12 @@ export class App extends React.Component<AppProps, AppState> {
             //TODO: disconnect sensor connector manager
             console.log("disconnect wired");
         } else {
-            const currentSensorManager = new SensorConnectorManager();
-            this.setState({
-                sensorManager: currentSensorManager
-            });
-            this.addSensorManagerListeners();
-            this.state.sensorManager!.startPolling();
+            const sensorManager = new SensorConnectorManager();
+            this.setState({ sensorManager }, () => {
+                    this.addSensorManagerListeners();
+                    this.state.sensorManager!.startPolling();
+                }
+            );
         }
     }
 
@@ -353,27 +353,25 @@ export class App extends React.Component<AppProps, AppState> {
 
             console.log(wirelessDevice);
             const isGDX = wirelessDevice.name.includes("GDX");
-            let currentSensorManager;
+            let sensorManager;
             if (isGDX) {
                 console.log("create sensorGDXManager")
-                currentSensorManager = new SensorGDXManager();
+                sensorManager = new SensorGDXManager();
             } else {
                 console.log("create sensorTagManager")
-                currentSensorManager = new SensorTagManager();
+                sensorManager = new SensorTagManager();
             }
 
             this.removeSensorManagerListeners();
 
-            this.setState({
-                sensorManager: currentSensorManager
-            });
-
-            this.addSensorManagerListeners();
-            this.state.sensorManager!.startPolling();
-
-            if(isConnectableSensorManager(this.state.sensorManager)){
-                this.state.sensorManager.connectToDevice(wirelessDevice);
-            }
+            this.setState({ sensorManager }, () => {
+                    this.addSensorManagerListeners();
+                    this.state.sensorManager!.startPolling();
+                    if(isConnectableSensorManager(this.state.sensorManager)) {
+                        this.state.sensorManager.connectToDevice(wirelessDevice);
+                    }
+                }
+            );
         } catch (err) {
             console.log("No wireless device selected");
         }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -315,9 +315,13 @@ export class App extends React.Component<AppProps, AppState> {
 
     async connectWirelessDevice() {
         try {
-            let optionalServices = SensorTagManager.getOptionalServices();
-            optionalServices = optionalServices.concat(SensorGDXManager.getOptionalServices());
-            let wirelessFilters: any[] = SensorTagManager.getWirelessFilters();
+            let optionalServices: any[] = [];
+            let wirelessFilters: any[] = [];
+            [SensorTagManager, SensorGDXManager].forEach(mgrClass => {
+              optionalServices.push(...mgrClass.getOptionalServices());
+              wirelessFilters.push(...mgrClass.getWirelessFilters());
+            });
+
             wirelessFilters = wirelessFilters.concat(SensorGDXManager.getWirelessFilters());
             // Step 1: ask for a device
             console.log("Displaying matching wireless devices...");
@@ -667,7 +671,11 @@ export class App extends React.Component<AppProps, AppState> {
         if (sensorManager) {
             sensorManager.requestSleep();
             // pause before attempting to reload SensorConnector
-            setTimeout(() => sensorManager.requestWake(), SLEEP_WAKE_DELAY_SEC * 1000);
+            setTimeout(() => {
+                if (sensorManager) {
+                    sensorManager.requestWake();
+                }
+            }, SLEEP_WAKE_DELAY_SEC * 1000);
         }
     }
 

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -11,7 +11,7 @@ import { IStringMap, SensorStrings, SensorDefinitions, sensorTagIdentifier,
          goDirectDevicePrefix, sensorTagAddrs, goDirectServiceUUID } from "../models/sensor-definitions";
 import { SensorManager, NewSensorData, ConnectableSensorManager } from "../models/sensor-manager";
 import SmartFocusHighlight from "../utils/smart-focus-highlight";
-import { find, pull, sumBy } from "lodash";
+import { find, pull, sumBy, cloneDeep } from "lodash";
 import Button from "./smart-highlight-button";
 import { SensorConnectorManager } from "../models/sensor-connector-manager";
 import { SensorTagManager } from "../models/sensor-tag-manager";
@@ -471,7 +471,10 @@ export class App extends React.Component<AppProps, AppState> {
             if (!cache) {
                 cache = this.columnInfoCache[columnID] = [];
             }
-            cache.push(dataColumn);
+            // make a deep copy to ensure that we don't have the
+            // same date object in each cache index
+            const dataColumnClone = cloneDeep(dataColumn);
+            cache.push(dataColumnClone);
             let stuck = false;
             if (cache.length > 4) {
                 stuck = true;

--- a/src/examples/wired-wireless.tsx
+++ b/src/examples/wired-wireless.tsx
@@ -1,16 +1,12 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as ReactModal from "react-modal";
-import { App } from "./components/app";
-import { SensorConnectorManager } from "./models/sensor-connector-manager";
-
-let sensorManager = new SensorConnectorManager();
+import { App } from "../components/app";
 
 const appElt = document.getElementById("app");
 ReactModal.setAppElement(appElt);
 
 ReactDOM.render(
-    <App
-      sensorManager={sensorManager}/>,
+    <App/>,
     appElt
 );

--- a/src/models/fake-sensor-manager.ts
+++ b/src/models/fake-sensor-manager.ts
@@ -4,7 +4,7 @@ import { SensorConfig } from "@concord-consortium/sensor-connector-interface";
 
 export class FakeSensorManager extends SensorManager {
     supportsDualCollection = true;
-    
+
     // private sensorConfig: SensorConfiguration;
     private internalConfig: SensorConfig;
     private hasData: boolean = false;
@@ -69,6 +69,10 @@ export class FakeSensorManager extends SensorManager {
         }
       };
       // this.sensorConfig = new SensorConfiguration(this.internalConfig);
+    }
+
+    isWirelessDevice() {
+      return false;
     }
 
     startPolling() {

--- a/src/models/sensor-connector-manager.ts
+++ b/src/models/sensor-connector-manager.ts
@@ -49,7 +49,6 @@ export class SensorConnectorManager extends SensorManager {
     }
 
     removeListeners() {
-      console.log("turn off listeners...");
       this.sensorConnector.off();
     }
 

--- a/src/models/sensor-connector-manager.ts
+++ b/src/models/sensor-connector-manager.ts
@@ -40,6 +40,10 @@ export class SensorConnectorManager extends SensorManager {
       this.sensorConnector.on("launchTimedOut", this.handleCommunicationError);
     }
 
+    isWirelessDevice() {
+      return false;
+    }
+
     startPolling() {
       // triggers initial connection to SensorConnector application
       this.sensorConnector.startPolling(SENSOR_IP);

--- a/src/models/sensor-connector-manager.ts
+++ b/src/models/sensor-connector-manager.ts
@@ -48,6 +48,11 @@ export class SensorConnectorManager extends SensorManager {
       this.sensorConnector.requestStop();
     }
 
+    removeListeners() {
+      console.log("turn off listeners...");
+      this.sensorConnector.off();
+    }
+
     hasSensorData() {
       const dataSet = this.sensorConnector.datasets[0];
       return !!(dataSet && dataSet.columns[1]);
@@ -73,7 +78,7 @@ export class SensorConnectorManager extends SensorManager {
     requestSleep() {
       this.sensorConnector.requestExit();
     }
-  
+
     requestWake(): boolean {
       return this.sensorConnector.requestLaunch();
     }
@@ -81,7 +86,7 @@ export class SensorConnectorManager extends SensorManager {
     handleCommunicationError = () => {
       this.onCommunicationError();
     }
-    
+
     handleSensorConnect = () => {
         const statusReceived = this.sensorConnector.currentActionArgs,
             config = statusReceived[1];

--- a/src/models/sensor-definitions.ts
+++ b/src/models/sensor-definitions.ts
@@ -69,7 +69,7 @@ export const SensorStrings:ISensorStrings = {
       "try_again": "Try Again",
       "cancel": "Cancel",
       "check_save": "Pressing New Run without pressing Save Data will discard the current data. Set up a new run without saving the data first?",
-      "bluetooth_connection_failed": "Failed to connect to bluetooth sensor. Try connecting to the sensor again.",
+      "bluetooth_connection_failed": "Failed to connect to Bluetooth sensor. Try connecting to the sensor again. If the problem persists, try restarting the sensor, refreshing your browser, unpairing and repairing the sensor, or turning your system's Bluetooth off and then on.",
     },
     "measurements": {
       "sensor_reading": "Sensor Reading",
@@ -653,5 +653,37 @@ export const SensorDefinitions:ISensorDefinitions = {
     "tareable": false,
     "minReading": -35.0,
     "maxReading": 35.0
+  }
+};
+
+export const sensorTagIdentifier = 0xaa80; // used to identify sensor tag
+export const goDirectDevicePrefix = "GDX"; // used to identify go direct sensors
+export const goDirectServiceUUID = "d91714ef-28b9-4f91-ba16-f0d9a604f112";
+export interface ISensorAddrs {
+  service: string;
+  data: string;
+  config: string;
+}
+
+export const sensorTagAddrs: { [index:string] : ISensorAddrs } = {
+  luxometer: {
+    service: 'f000aa70-0451-4000-b000-000000000000',
+    data: 'f000aa71-0451-4000-b000-000000000000',
+    config: 'f000aa72-0451-4000-b000-000000000000'
+  },
+  humidity: {
+    service: 'f000aa20-0451-4000-b000-000000000000',
+    data: 'f000aa21-0451-4000-b000-000000000000', // TempLSB:TempMSB:HumidityLSB:HumidityMSB
+    config: 'f000aa22-0451-4000-b000-000000000000'
+  },
+  IRTemperature: {
+    service: 'f000aa00-0451-4000-b000-000000000000',
+    data: 'f000aa01-0451-4000-b000-000000000000', // ObjectLSB:ObjectMSB:AmbientLSB:AmbientMSB
+    config: 'f000aa02-0451-4000-b000-000000000000'
+  },
+  IO: {
+    service: 'f000aa64-0451-4000-b000-000000000000',
+    data: 'f000aa65-0451-4000-b000-000000000000',
+    config: 'f000aa66-0451-4000-b000-000000000000'
   }
 };

--- a/src/models/sensor-definitions.ts
+++ b/src/models/sensor-definitions.ts
@@ -70,6 +70,7 @@ export const SensorStrings:ISensorStrings = {
       "cancel": "Cancel",
       "check_save": "Pressing New Run without pressing Save Data will discard the current data. Set up a new run without saving the data first?",
       "bluetooth_connection_failed": "Failed to connect to Bluetooth sensor. Try connecting to the sensor again. If the problem persists, try restarting the sensor, refreshing your browser, unpairing and repairing the sensor, or turning your system's Bluetooth off and then on.",
+      "sensor_disconnection_warning": "Bluetooth sensor disconnection detected. Check Bluetooth sensor power and battery level before attempting reconnection.",
     },
     "measurements": {
       "sensor_reading": "Sensor Reading",

--- a/src/models/sensor-definitions.ts
+++ b/src/models/sensor-definitions.ts
@@ -68,7 +68,8 @@ export const SensorStrings:ISensorStrings = {
       "sensor_or_device_unplugged": "The __sensor_or_device_name__ was unplugged. Try plugging it back in, and then click \"$t(sensor.messages.try_again)\".",
       "try_again": "Try Again",
       "cancel": "Cancel",
-      "check_save": "Pressing New Run without pressing Save Data will discard the current data. Set up a new run without saving the data first?"
+      "check_save": "Pressing New Run without pressing Save Data will discard the current data. Set up a new run without saving the data first?",
+      "bluetooth_connection_failed": "Failed to connect to bluetooth sensor. Try connecting to the sensor again.",
     },
     "measurements": {
       "sensor_reading": "Sensor Reading",

--- a/src/models/sensor-definitions.ts
+++ b/src/models/sensor-definitions.ts
@@ -655,35 +655,3 @@ export const SensorDefinitions:ISensorDefinitions = {
     "maxReading": 35.0
   }
 };
-
-export const sensorTagIdentifier = 0xaa80; // used to identify sensor tag
-export const goDirectDevicePrefix = "GDX"; // used to identify go direct sensors
-export const goDirectServiceUUID = "d91714ef-28b9-4f91-ba16-f0d9a604f112";
-export interface ISensorAddrs {
-  service: string;
-  data: string;
-  config: string;
-}
-
-export const sensorTagAddrs: { [index:string] : ISensorAddrs } = {
-  luxometer: {
-    service: 'f000aa70-0451-4000-b000-000000000000',
-    data: 'f000aa71-0451-4000-b000-000000000000',
-    config: 'f000aa72-0451-4000-b000-000000000000'
-  },
-  humidity: {
-    service: 'f000aa20-0451-4000-b000-000000000000',
-    data: 'f000aa21-0451-4000-b000-000000000000', // TempLSB:TempMSB:HumidityLSB:HumidityMSB
-    config: 'f000aa22-0451-4000-b000-000000000000'
-  },
-  IRTemperature: {
-    service: 'f000aa00-0451-4000-b000-000000000000',
-    data: 'f000aa01-0451-4000-b000-000000000000', // ObjectLSB:ObjectMSB:AmbientLSB:AmbientMSB
-    config: 'f000aa02-0451-4000-b000-000000000000'
-  },
-  IO: {
-    service: 'f000aa64-0451-4000-b000-000000000000',
-    data: 'f000aa65-0451-4000-b000-000000000000',
-    config: 'f000aa66-0451-4000-b000-000000000000'
-  }
-};

--- a/src/models/sensor-gdx-manager.ts
+++ b/src/models/sensor-gdx-manager.ts
@@ -128,7 +128,7 @@ export class SensorGDXManager extends SensorManager {
       return batteryLevel;
     }
 
-    async connectToDevice(device?: any) {
+    async connectToDevice(device?: any): Promise<boolean> {
       this.gdxDevice = await godirect.createDevice(device);
 
       if(!this.gdxDevice) {

--- a/src/models/sensor-gdx-manager.ts
+++ b/src/models/sensor-gdx-manager.ts
@@ -121,6 +121,7 @@ export class SensorGDXManager extends SensorManager {
       this.enabledSensors = this.gdxDevice.sensors.filter((s: any) => s.enabled);
       console.log(this.enabledSensors);
       //read the enabled sensors and construct columns
+      //TODO: need to make a column for each enabledsensor
       this.internalConfig.columns["100"].name = this.enabledSensors[0].name;
       let newUnits = this.enabledSensors[0].unit;
       if (newUnits === "°C") {

--- a/src/models/sensor-gdx-manager.ts
+++ b/src/models/sensor-gdx-manager.ts
@@ -3,6 +3,12 @@ import { SensorManager, NewSensorData } from "./sensor-manager";
 import { SensorConfig } from "@concord-consortium/sensor-connector-interface";
 import godirect from "@vernier/godirect"
 
+const goDirectServiceUUID = "d91714ef-28b9-4f91-ba16-f0d9a604f112";
+const goDirectDevicePrefix = "GDX";
+
+const POLLING_INTERVAL = 1000;
+const READ_DATA_INTERVAL = 10;
+
 export class SensorGDXManager extends SensorManager {
     supportsDualCollection = true;
 
@@ -40,6 +46,14 @@ export class SensorGDXManager extends SensorManager {
       };
     }
 
+    static getOptionalServices() {
+      return [goDirectServiceUUID];
+    }
+
+    static getWirelessFilters() {
+      return [{ namePrefix: [goDirectDevicePrefix] }];
+    }
+
     sendSensorConfig(includeOnConnect:boolean) {
       let sensorConfig = new SensorConfiguration(this.internalConfig);
       if (includeOnConnect) {
@@ -55,8 +69,12 @@ export class SensorGDXManager extends SensorManager {
       setInterval(() => {
         //TODO: do we need to cancel while collecting or while disconnected?
         this.pollSensor();
-      }, 1000);
+      }, POLLING_INTERVAL);
 
+    }
+
+    isWirelessDevice() {
+      return true;
     }
 
     pollSensor() {
@@ -91,7 +109,7 @@ export class SensorGDXManager extends SensorManager {
 
         if (!this.stopRequested) {
           // Repeat
-          setTimeout(readData, 10);
+          setTimeout(readData, READ_DATA_INTERVAL);
         } else {
           this.onSensorCollectionStopped();
           this.stopRequested = false;

--- a/src/models/sensor-gdx-manager.ts
+++ b/src/models/sensor-gdx-manager.ts
@@ -1,0 +1,180 @@
+import { SensorConfiguration } from "./sensor-configuration";
+import { SensorManager, NewSensorData } from "./sensor-manager";
+import { SensorConfig } from "@concord-consortium/sensor-connector-interface";
+import { cloneDeep } from "lodash";
+import godirect from "@vernier/godirect"
+
+
+const sensorDescriptions = {
+  temperature: {
+    sensorName: "temperature",
+    values: [
+      {
+        columnID: "101"
+      }
+    ]
+  }
+};
+
+export class SensorGDXManager extends SensorManager {
+    supportsDualCollection = true;
+
+    // private sensorConfig: SensorConfiguration;
+    private internalConfig: SensorConfig;
+    private hasData: boolean = false;
+    private stopRequested: boolean = false;
+    private gdxDevice: any;
+    private enabledSensors: any;
+
+    constructor() {
+      super();
+      // create fake SensorConfiguration
+      // This should be improved, we don't need all of these properties when making
+      // a new sensor manager. The SensorConfiguration class could be have an
+      // interface so then sensor managers can provide their own implementation
+      this.internalConfig = {
+        collection:{ canControl:true, isCollecting:false },
+        columnListTimeStamp: new Date(),
+        columns:{
+          "100": {
+            id: "100",
+            setID: "100",
+            position: 0,
+            name: "Time",
+            units: "s",
+            liveValue: "NaN",
+            liveValueTimeStamp: new Date(),
+            valueCount: 0,
+            valuesTimeStamp: new Date()
+          },
+          "101": {
+            id: "101",
+            setID: "100",
+            position: 1,
+            name: "Temperature",
+            units: "degC",
+            liveValue: "NaN",
+            liveValueTimeStamp: new Date(),
+            valueCount: 0,
+            valuesTimeStamp: new Date()
+          }
+        },
+        currentInterface: "GDX Sensor",
+        currentState: "unknown",
+        os: { name: "Fake", version: "1.0.0"},
+        requestTimeStamp: new Date(),
+        server: { arch: "Fake", version: "1.0.0" },
+        sessionDesc: "Fake",
+        sessionID: "1234",
+        sets:{
+          "100": {
+            name: "Run 1",
+            colIDs: [100, 101, 102]
+          }
+        }
+      };
+      // this.sensorConfig = new SensorConfiguration(this.internalConfig);
+    }
+
+    sendSensorConfig(includeOnConnect:boolean) {
+      let sensorConfig = new SensorConfiguration(this.internalConfig);
+      if(includeOnConnect) {
+        this.onSensorConnect(sensorConfig);
+      }
+      this.onSensorStatus(sensorConfig);
+    }
+
+    startPolling() {
+      setTimeout(() => {
+        let sensorConfig = new SensorConfiguration(this.internalConfig);
+        this.onSensorConnect(sensorConfig);
+        this.onSensorStatus(sensorConfig);
+      }, 100);
+    }
+
+    hasSensorData() {
+      return this.hasData;
+    }
+
+    requestStart() {
+      // cloneDeep is used because we are saving the dataCharacteristic on this object
+      // and that will change after the device is disconnected and reconnected
+
+      const activeSensors = [ cloneDeep(sensorDescriptions.temperature) ];
+      console.log(activeSensors);
+
+      console.log("Reading GDX measurements");
+
+      this.gdxDevice.on('device-closed', () => {
+          console.log("Disconnected from GDX device " + this.gdxDevice.name);
+      });
+
+      let startCollectionTime = Date.now();
+
+      const readData = async () => {
+
+        this.enabledSensors.forEach((sensor: any) => {
+            // log the sensor name, new value and units.
+            const time = Date.now() - startCollectionTime;
+            // console.log("Sensor: " + sensor.name + " /  value: " + sensor.value + " /  units: " + sensor.unit);
+            this.updateSensorValue("101", time / 1000, sensor.value);
+        });
+
+        if(!this.stopRequested) {
+          // Repeat
+          setTimeout(readData, 10);
+        } else {
+          this.onSensorCollectionStopped();
+          this.stopRequested = false;
+        }
+      };
+
+      readData();
+
+    }
+
+    updateSensorValue(ID:string, time:number, value:number) {
+      this.internalConfig.columns[ID].liveValue = value.toString();
+      this.hasData = true;
+
+      this.onSensorStatus(new SensorConfiguration(this.internalConfig));
+      const data:NewSensorData = {};
+      data[ID] = [[time, value]];
+      this.onSensorData(data);
+    }
+
+    requestStop() {
+      this.stopRequested = true;
+    }
+
+    async connectToDevice(device?: any) {
+      console.log("create gdxDevice")
+      this.gdxDevice = await godirect.createDevice(device);
+
+      console.log(this.gdxDevice);
+      console.log("Connected to GDX device " + this.gdxDevice.name);
+
+      this.gdxDevice.enableDefaultSensors();
+      this.enabledSensors = this.gdxDevice.sensors.filter((s: any) => s.enabled);
+/*
+      console.log("Reading GDX measurement ");
+
+      this.gdxDevice.on('device-closed', () => {
+          console.log("Disconnected from GDX device " + this.gdxDevice.name);
+      });
+
+
+      enabledSensors.forEach((sensor: any) => {
+          sensor.on("value-changed", (sensor: any) => {
+            // Only collect 10 samples and disconnect.
+            if (sensor.values.length > 10){
+              this.gdxDevice.close();
+            }
+            // log the sensor name, new value and units.
+            console.log("Sensor: " + sensor.name + " /  value: " + sensor.value + " /  units: " + sensor.unit);
+          });
+      });
+      */
+    }
+
+}

--- a/src/models/sensor-manager.ts
+++ b/src/models/sensor-manager.ts
@@ -29,6 +29,7 @@ export abstract class SensorManager {
   abstract hasSensorData() : boolean;
   abstract requestStart() : void;
   abstract requestStop() : void;
+  abstract isWirelessDevice() : boolean;
 
   isAwake() : boolean {
     return true;

--- a/src/models/sensor-manager.ts
+++ b/src/models/sensor-manager.ts
@@ -17,7 +17,7 @@ export interface ConnectableSensorManager {
   // The sensor-interactive code will use connectToDevice to determine
   // if the sensorManager instance implements ConnectableSensorManager
   // typescript doesn't have runtime type checking
-  connectToDevice: (device?: any) => void;
+  connectToDevice: (device?: any) => Promise<boolean>;
   disconnectFromDevice: () => void;
   deviceConnected: boolean;
 }

--- a/src/models/sensor-manager.ts
+++ b/src/models/sensor-manager.ts
@@ -17,14 +17,14 @@ export interface ConnectableSensorManager {
   // The sensor-interactive code will use connectToDevice to determine
   // if the sensorManager instance implements ConnectableSensorManager
   // typescript doesn't have runtime type checking
-  connectToDevice: () => void;
+  connectToDevice: (device?: any) => void;
   disconnectFromDevice: () => void;
   deviceConnected: boolean;
 }
 
 export abstract class SensorManager {
   supportsDualCollection: boolean;
-  
+
   abstract startPolling() : void;
   abstract hasSensorData() : boolean;
   abstract requestStart() : void;

--- a/src/models/sensor-manager.ts
+++ b/src/models/sensor-manager.ts
@@ -84,6 +84,10 @@ export abstract class SensorManager {
     this.notifyListeners('onSensorConnect', sensorConfig);
   }
 
+  protected onSensorDisconnect() {
+    this.notifyListeners('onSensorDisconnect');
+  }
+
   protected onSensorData(newData:NewSensorData) {
     this.notifyListeners('onSensorData', newData);
   }

--- a/src/models/sensor-tag-manager.ts
+++ b/src/models/sensor-tag-manager.ts
@@ -305,7 +305,7 @@ export class SensorTagManager extends SensorManager implements ConnectableSensor
       this.stopRequested = true;
     }
 
-    async connectToDevice(device?: any) {
+    async connectToDevice(device?: any): Promise<boolean> {
       if (device) {
         this.device = device;
       } else {
@@ -326,6 +326,8 @@ export class SensorTagManager extends SensorManager implements ConnectableSensor
 
       // Make the green led go solid so we know we are connected
       this.turnOnGreenLED();
+
+      return true;
     }
 
     async turnOnGreenLED() {

--- a/src/models/sensor-tag-manager.ts
+++ b/src/models/sensor-tag-manager.ts
@@ -305,15 +305,19 @@ export class SensorTagManager extends SensorManager implements ConnectableSensor
       this.stopRequested = true;
     }
 
-    async connectToDevice() {
-      // Step 1: ask for a device
-      this.device = await navigator.bluetooth.requestDevice({
+    async connectToDevice(device?: any) {
+      if (device) {
+        this.device = device;
+      } else {
+        // Step 1: ask for a device
+        this.device = await navigator.bluetooth.requestDevice({
           filters: [{ services: [tagIdentifier] }],
           optionalServices: [tagAddrs.luxometer.service,
-                             tagAddrs.humidity.service,
-                             tagAddrs.IRTemperature.service,
-                             tagAddrs.IO.service]
+                            tagAddrs.humidity.service,
+                            tagAddrs.IRTemperature.service,
+                            tagAddrs.IO.service]
         });
+      }
       // Step 2: Connect to device
       this.server = await this.device.gatt.connect();
 

--- a/src/models/sensor-tag-manager.ts
+++ b/src/models/sensor-tag-manager.ts
@@ -2,8 +2,37 @@ import { SensorConfiguration } from "./sensor-configuration";
 import { SensorManager,
          NewSensorData, ConnectableSensorManager } from "./sensor-manager";
 import { SensorConfig } from "@concord-consortium/sensor-connector-interface";
-import { sensorTagIdentifier, sensorTagAddrs } from "./sensor-definitions";
 import { cloneDeep } from "lodash";
+
+const tagIdentifier = 0xaa80;
+interface ISensorAddrs {
+  service: string;
+  data: string;
+  config: string;
+}
+
+const tagAddrs: { [index:string] : ISensorAddrs } = {
+  luxometer: {
+    service: 'f000aa70-0451-4000-b000-000000000000',
+    data: 'f000aa71-0451-4000-b000-000000000000',
+    config: 'f000aa72-0451-4000-b000-000000000000'
+  },
+  humidity: {
+    service: 'f000aa20-0451-4000-b000-000000000000',
+    data: 'f000aa21-0451-4000-b000-000000000000', // TempLSB:TempMSB:HumidityLSB:HumidityMSB
+    config: 'f000aa22-0451-4000-b000-000000000000'
+  },
+  IRTemperature: {
+    service: 'f000aa00-0451-4000-b000-000000000000',
+    data: 'f000aa01-0451-4000-b000-000000000000', // ObjectLSB:ObjectMSB:AmbientLSB:AmbientMSB
+    config: 'f000aa02-0451-4000-b000-000000000000'
+  },
+  IO: {
+    service: 'f000aa64-0451-4000-b000-000000000000',
+    data: 'f000aa65-0451-4000-b000-000000000000',
+    config: 'f000aa66-0451-4000-b000-000000000000'
+  }
+};
 
 // http://processors.wiki.ti.com/index.php/CC2650_SensorTag_User%27s_Guide
 const IR_SCALE_LSB = 0.03125;
@@ -183,12 +212,27 @@ export class SensorTagManager extends SensorManager implements ConnectableSensor
       // this.sensorConfig = new SensorConfiguration(this.internalConfig);
     }
 
+    static getOptionalServices() {
+      return [tagAddrs.luxometer.service,
+              tagAddrs.humidity.service,
+              tagAddrs.IRTemperature.service,
+              tagAddrs.IO.service];
+    }
+
+    static getWirelessFilters() {
+      return [{ services: [tagIdentifier] }];
+    }
+
     sendSensorConfig(includeOnConnect:boolean) {
       let sensorConfig = new SensorConfiguration(this.internalConfig);
       if(includeOnConnect) {
         this.onSensorConnect(sensorConfig);
       }
       this.onSensorStatus(sensorConfig);
+    }
+
+    isWirelessDevice() {
+      return true;
     }
 
     startPolling() {
@@ -282,11 +326,11 @@ export class SensorTagManager extends SensorManager implements ConnectableSensor
       } else {
         // Step 1: ask for a device
         this.device = await navigator.bluetooth.requestDevice({
-          filters: [{ services: [sensorTagIdentifier] }],
-          optionalServices: [sensorTagAddrs.luxometer.service,
-                             sensorTagAddrs.humidity.service,
-                             sensorTagAddrs.IRTemperature.service,
-                             sensorTagAddrs.IO.service]
+          filters: [{ services: [tagIdentifier] }],
+          optionalServices: [tagAddrs.luxometer.service,
+                             tagAddrs.humidity.service,
+                             tagAddrs.IRTemperature.service,
+                             tagAddrs.IO.service]
         });
       }
       // Step 2: Connect to device
@@ -308,7 +352,7 @@ export class SensorTagManager extends SensorManager implements ConnectableSensor
 
       // Get the IO service
       const service =
-        await this.server.getPrimaryService(sensorTagAddrs.IO.service);
+        await this.server.getPrimaryService(tagAddrs.IO.service);
 
       // The order is important, by default the data value is 0x7F which
       // is enables flashing lights and beep. Not fun!
@@ -316,12 +360,12 @@ export class SensorTagManager extends SensorManager implements ConnectableSensor
 
       // Set data so the green led will turn on when remote control is set
       const dataChar =
-        await service.getCharacteristic(sensorTagAddrs.IO.data);
+        await service.getCharacteristic(tagAddrs.IO.data);
       await dataChar.writeValue(new Uint8Array([0x02]));
 
       // Enable Remote IO control
       const configChar =
-        await service.getCharacteristic(sensorTagAddrs.IO.config);
+        await service.getCharacteristic(tagAddrs.IO.config);
       await configChar.writeValue(new Uint8Array([0x01]));
     }
 
@@ -354,7 +398,7 @@ export class SensorTagManager extends SensorManager implements ConnectableSensor
     }
 
     async setupSensor(sensorDescription:any) {
-      const sensorAddrs = sensorTagAddrs[sensorDescription.sensorName];
+      const sensorAddrs = tagAddrs[sensorDescription.sensorName];
 
       // Step 3: Get the Service
       const service = await this.server.getPrimaryService(sensorAddrs.service);

--- a/src/models/thermoscope-manager.ts
+++ b/src/models/thermoscope-manager.ts
@@ -225,7 +225,7 @@ export class ThermoscopeManager extends SensorManager implements ConnectableSens
       this.stopRequested = true;
     }
 
-    async connectToDevice() {
+    async connectToDevice(): Promise<boolean> {
       // ask for a device
       this.device = await navigator.bluetooth.requestDevice({
           filters: [{ namePrefix:  "Thermoscope" }],
@@ -237,6 +237,8 @@ export class ThermoscopeManager extends SensorManager implements ConnectableSens
 
       // Resend the sensorconfig so the UI udpates after the connection
       this.sendSensorConfig(true);
+
+      return true;
     }
 
     get deviceConnected() {

--- a/src/models/thermoscope-manager.ts
+++ b/src/models/thermoscope-manager.ts
@@ -135,6 +135,10 @@ export class ThermoscopeManager extends SensorManager implements ConnectableSens
       this.onSensorStatus(sensorConfig);
     }
 
+    isWirelessDevice() {
+      return true;
+    }
+
     startPolling() {
       setTimeout(() => {
         this.sendSensorConfig(true);

--- a/src/public/examples/wired-wireless.html
+++ b/src/public/examples/wired-wireless.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Sensor Interactive</title>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="shortcut icon" href="../favicon.ico" type="image/vnd.microsoft.icon" />
+    <!-- TODO: bundle with WebPack -->
+    <link rel="stylesheet" href="../assets/fonts/font-awesome-4.7.0/css/font-awesome.css">
+    <link rel="stylesheet" href="../assets/css/dygraph.css">
+    <link rel="stylesheet" href="../assets/css/dialog.css">
+    <link rel="stylesheet" href="../assets/css/app.css">
+  </head>
+  <body>
+    <div id="app"></div>
+
+    <script src="../assets/js/globals.js"></script>
+    <script src="../assets/js/iframe-phone.js"></script>
+    <script src="../assets/js/CodapInterface.js"></script>
+    <script src="../assets/js/examples/wired-wireless.js"></script>
+  </body>
+</html>

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,2 +1,3 @@
 declare module 'react-modal';
 declare module 'react-sizeme';
+declare module '@vernier/godirect';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ module.exports = {
         "examples/fake-sensor": "./src/examples/fake-sensor.tsx",
         "examples/sensor-tag": "./src/examples/sensor-tag.tsx",
         "examples/thermoscope": "./src/examples/thermoscope.tsx",
+        "examples/wired-wireless": "./src/examples/wired-wireless.tsx",
         globals: Object.keys(pkg.dependencies)
     },
     output: {


### PR DESCRIPTION
Initial implementation of connecting to and reading Vernier Go Direct sensors via Bluetooth and allowing users the option to connect to sensors via USB ("wired") or via Bluetooth ("wireless").  At present this implementation is confined to an example page: examples/wired-wireless.html.  Existing example pages (fake-sensor.html, sensor-tag.html, etc.) and the main sensor-interactive page should behave as they did previously (if a `sensorManager` object is passed to the `App` React component, we use that sensor manager type to connect to sensors and proceed as we did previously.  Otherwise, if no `sensorManager` object is passed to the `App` React component, we show the new wired/wireless implementation).  

In this new wired/wireless connection implementation, the following occurs:
- when the app is loaded, sensor-connector is no longer auto-launched.  Instead "connect to wired" and "connect to wireless" buttons are shown allowing the user to choose the connection method.
- if the user connects to wired, then we launch the sensor-connector app and sensor-interactive behaves as it did previously (user can connect to USB sensors).  The "connect to wireless" button is disabled and a button is shown to "disconnect from wired" which allows the user to stop communicating with the sensor-connector app and again choose the connection method.  
- if the user connects to wireless, then we display a Chrome dialog of matching Bluetooth sensors (Go Direct and Sensor Tag) which the user can connect to.  The "connect to wired" button is disabled and a button is shown to "disconnect from wireless" which allows the user to stop communicating with a connected Bluetooth sensor and again choose the connection method.
- once connected to a Bluetooth sensor, the user can use the normal sensor-interactive functionality to choose sensors channels, see live sensor readings, collect data, view channels side-by-side, etc.  