### PR TITLE
Improve status indicator light state when using wired sensors

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -819,10 +819,16 @@ export class App extends React.Component<AppProps, AppState> {
         const { sensorManager, sensorConfig } = this.state;
         let wirelessIconClass = "wireless-status-icon ";
         if (sensorManager != null) {
-            if (sensorConfig && sensorConfig.hasInterface || !sensorManager.isWirelessDevice()) {
-                wirelessIconClass = wirelessIconClass + "connected";
+            if (sensorManager.isWirelessDevice()) {
+                if (sensorConfig && sensorConfig.hasInterface) {
+                    wirelessIconClass = wirelessIconClass + "connected";
+                } else {
+                    wirelessIconClass = wirelessIconClass + "connecting";
+                }
             } else {
-                wirelessIconClass = wirelessIconClass + "connecting";
+                if (sensorConfig && sensorConfig.hasInterface) {
+                    wirelessIconClass = wirelessIconClass + "connected";
+                }
             }
         }
         return (


### PR DESCRIPTION
When in wired mode, only show green connected light if we actually have a connected sensor (previously turned the light green as soon as user pressed "wired" button).  This code could be condensed, but I would like to keep the wired and wireless cases separate since they will almost certainly diverge further in the future. 