### PR TITLE
164872900 change sampling rate

### DIFF
--- a/src/models/sensor-gdx-manager.ts
+++ b/src/models/sensor-gdx-manager.ts
@@ -7,7 +7,7 @@ const goDirectServiceUUID = "d91714ef-28b9-4f91-ba16-f0d9a604f112";
 const goDirectDevicePrefix = "GDX";
 
 const POLLING_INTERVAL = 1000;
-const READ_DATA_INTERVAL = 10;
+const READ_DATA_INTERVAL = 50;
 
 export class SensorGDXManager extends SensorManager {
     supportsDualCollection = true;

--- a/src/models/sensor-gdx-manager.ts
+++ b/src/models/sensor-gdx-manager.ts
@@ -19,6 +19,7 @@ export class SensorGDXManager extends SensorManager {
     private gdxDevice: any;
     private enabledSensors: any;
     private initialColumnNum = 100;
+    private timerId: any;
 
     constructor() {
       super();
@@ -105,16 +106,14 @@ export class SensorGDXManager extends SensorManager {
           this.updateSensorValue(cNum.toString(), time / 1000, sensor.value);
         });
 
-        if (!this.stopRequested) {
-          // Repeat
-          setTimeout(readData, READ_DATA_INTERVAL);
-        } else {
+        if (this.stopRequested) {
+          clearInterval(this.timerId);
           this.onSensorCollectionStopped();
           this.stopRequested = false;
         }
       };
 
-      readData();
+      this.timerId = setInterval(readData, READ_DATA_INTERVAL);
 
     }
 

--- a/src/models/sensor-gdx-manager.ts
+++ b/src/models/sensor-gdx-manager.ts
@@ -141,7 +141,7 @@ export class SensorGDXManager extends SensorManager {
     }
 
     async connectToDevice(device?: any): Promise<boolean> {
-      this.gdxDevice = await godirect.createDevice(device);
+      this.gdxDevice = await godirect.createDevice(device, { open: true, startMeasurements: false });
 
       if (!this.gdxDevice) {
         console.log("Could not create GDX device");
@@ -157,6 +157,9 @@ export class SensorGDXManager extends SensorManager {
           this.onSensorDisconnect();
         }
       });
+
+      // set a new interval and start measurements
+      this.gdxDevice.start(this.gdxDevice.minMeasurementPeriod);
 
       // turn on any default sensors
       this.gdxDevice.enableDefaultSensors();


### PR DESCRIPTION
When using Go Direct sensors, set the measurement period on the sensor to the minimum measurement period (was previously using the default period which tended to be 500 ms), and change our sampling rate to 50 ms (20 samples per second).  This should facilitate the intended 20 Hz sampling rate (since the sensors will now obtain new measurements more rapidly and we're requesting measurements at the intended rate). 