### PR TITLE
Set status indicator light to red if there are no sensors detected on a device

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -826,7 +826,7 @@ export class App extends React.Component<AppProps, AppState> {
                     wirelessIconClass = wirelessIconClass + "connecting";
                 }
             } else {
-                if (sensorConfig && sensorConfig.hasInterface) {
+                if (sensorConfig && sensorConfig.hasInterface && this.connectedSensorCount() > 0) {
                     wirelessIconClass = wirelessIconClass + "connected";
                 }
             }


### PR DESCRIPTION
Status indicator light was previously green if any interface was detected when in wired mode.  These changes should change the light to green only if an interface is detected and 1 or more valid sensors are also detected on the interface.