### PR TITLE
The new sensor tag has the aa20 service but not aa80

### DIFF
--- a/src/models/sensor-tag-manager.ts
+++ b/src/models/sensor-tag-manager.ts
@@ -4,7 +4,7 @@ import { SensorManager,
 import { SensorConfig } from "@concord-consortium/sensor-connector-interface";
 import { cloneDeep } from "lodash";
 
-const tagIdentifier = 0xaa80;
+const tagIdentifier = 0xaa20;
 interface ISensorAddrs {
   service: string;
   data: string;


### PR DESCRIPTION
The aa20 service is also the one used for ambient temperature and light which is what this sensor manager is 
currently hard coded for anyway.