### PR TITLE
171976391 expand fake sensor for testing

### DIFF
--- a/cypress/integration/branch/sensor-connection.test.js
+++ b/cypress/integration/branch/sensor-connection.test.js
@@ -5,8 +5,9 @@ const workspace = new Workspace
 before(()=>{
     cy.visit('/examples/fake-sensor.html')
 })
-context('Connecting a sensor',()=>{
+context('Connecting a wired sensor',()=>{
     it('verify status message shows connection',()=>{
+        workspace.getSensorTypeButton('Wired').click()
         workspace.getStatusIcon().should('be.visible').and ('have.class','connected')
         workspace.getStatusMessage().should('contain','Fake Sensor connected')
     })

--- a/src/examples/fake-sensor.tsx
+++ b/src/examples/fake-sensor.tsx
@@ -1,13 +1,10 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { App } from "../components/app";
-import { FakeSensorManager } from "../models/fake-sensor-manager";
-
-let sensorManager = new FakeSensorManager();
 
 ReactDOM.render(
     <App
-      sensorManager={sensorManager}
+      fakeSensor={true}
     />,
     document.getElementById("app")
 );


### PR DESCRIPTION
Expand the fake sensor page to include wired/wireless buttons and the ability to remove the initial sensor.  This allows us to more faithfully reproduce the actual sensor interactive page and facilitate Cypress testing.