### PR TITLE
Wire up existing sensor interactive app component [#181112352]

### DIFF
--- a/src/components/control-panel.tsx
+++ b/src/components/control-panel.tsx
@@ -19,7 +19,7 @@ interface IControlPanelProps {
   onStartCollecting: () => void;
   onStopCollecting: () => void;
   onNewRun: () => void;
-  onSaveData: () => void;
+  onSaveData: (() => void) | undefined;
   onReloadPage: () => void;
   onAboutClick: () => void;
   assetsPath: string;
@@ -76,11 +76,12 @@ export const ControlPanel: React.SFC<IControlPanelProps> = (props) => {
               disabled={disableStopCollecting}>
         Stop
       </Button>
+      {props.onSaveData ?
       <Button className="send-data control-panel-button"
               onClick={props.onSaveData}
               disabled={disableSendData}>
         Save Data
-      </Button>
+      </Button> : undefined}
       <Button className="new-data control-panel-button"
               onClick={props.onNewRun}
               disabled={disableNewData}>

--- a/src/components/graphs-panel.tsx
+++ b/src/components/graphs-panel.tsx
@@ -24,6 +24,7 @@ interface IGraphsPanelProps {
   dataReset:boolean;
   hasConnected:boolean;
   assetsPath: string;
+  maxHeight?: number;
 }
 
 const GraphsPanelImp: React.SFC<IGraphsPanelProps> = (props) => {
@@ -33,7 +34,8 @@ const GraphsPanelImp: React.SFC<IGraphsPanelProps> = (props) => {
                         isSingletonGraph:boolean,
                         isLastGraph:boolean = isSingletonGraph) {
     const sensorColumns = (props.sensorConfig && props.sensorConfig.dataColumns) || [],
-          availableHeight = props.size.height && (props.size.height - 20),
+          height = props.maxHeight || props.size.height,
+          availableHeight = height && (height - 20),
           singleGraphHeight = availableHeight && (availableHeight + 8),
           graphBaseHeight = availableHeight && Math.floor((availableHeight - 18) / 2),
           firstGraphHeight = graphBaseHeight,

--- a/src/interactive/app.tsx
+++ b/src/interactive/app.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useEffect } from "react";
 
-import { useInitMessage, setSupportedFeatures, useAutoSetHeight  } from "@concord-consortium/lara-interactive-api";
+import { useInitMessage, setSupportedFeatures, useAutoSetHeight } from "@concord-consortium/lara-interactive-api";
 import { AuthoringComponent } from "./authoring";
 import { ReportComponent } from "./report";
 import { RuntimeComponent } from "./runtime";

--- a/src/interactive/report.tsx
+++ b/src/interactive/report.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { IReportInitInteractive, useInteractiveState } from "@concord-consortium/lara-interactive-api";
+
 import { IInteractiveState } from "./types";
+import { App } from "../components/app";
 
 interface Props {
   initMessage: IReportInitInteractive;
@@ -10,15 +12,11 @@ export const ReportComponent: React.FC<Props> = ({initMessage}) => {
   const { interactiveState } = useInteractiveState<IInteractiveState>();
 
   return (
-    <div className="padded">
-      <fieldset>
-        <legend>Report Init Message</legend>
-        <div className="padded monospace pre">{JSON.stringify(initMessage, null, 2)}</div>
-      </fieldset>
-      <fieldset>
-        <legend>Report Interactive State</legend>
-        <div className="padded monospace pre">{JSON.stringify(interactiveState, null, 2)}</div>
-      </fieldset>
-    </div>
+    <App
+      interactiveHost="report"
+      fakeSensor={true}
+      maxGraphHeight={625}
+      interactiveState={interactiveState}
+    />
   );
 };

--- a/src/interactive/runtime.tsx
+++ b/src/interactive/runtime.tsx
@@ -1,9 +1,8 @@
 import * as React from "react";
-import { useEffect } from "react";
 import { IRuntimeInitInteractive, useInteractiveState } from "@concord-consortium/lara-interactive-api";
 
-import { IAuthoredState, IInteractiveState } from "./types";
-
+import { IAuthoredState, IInteractiveState, /* IInteractiveState */ } from "./types";
+import { App } from "../components/app";
 interface Props {
   initMessage: IRuntimeInitInteractive<{}, IAuthoredState>;
 }
@@ -11,20 +10,13 @@ interface Props {
 export const RuntimeComponent: React.FC<Props> = ({initMessage}) => {
   const { interactiveState, setInteractiveState } = useInteractiveState<IInteractiveState>();
 
-  useEffect(() => {
-    setInteractiveState({});
-  }, []);
-
   return (
-    <div className="padded">
-      <fieldset>
-        <legend>Runtime Init Message</legend>
-        <div className="padded monospace pre">{JSON.stringify(initMessage, null, 2)}</div>
-      </fieldset>
-      <fieldset>
-        <legend>Runtime Interactive State</legend>
-        <div className="padded monospace pre">{JSON.stringify(interactiveState, null, 2)}</div>
-      </fieldset>
-    </div>
+    <App
+      interactiveHost="runtime"
+      fakeSensor={true}
+      maxGraphHeight={625}
+      interactiveState={interactiveState}
+      setInteractiveState={setInteractiveState}
+    />
   );
 };

--- a/src/public/interactive/index.html
+++ b/src/public/interactive/index.html
@@ -7,6 +7,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="../favicon.ico" type="image/vnd.microsoft.icon" />
     <link rel="stylesheet" href="../assets/css/interactive/index.css">
+    <link rel="stylesheet" href="../assets/css/dygraph.css">
+    <link rel="stylesheet" href="../assets/css/dialog.css">
+    <link rel="stylesheet" href="../assets/css/app.css">
+    <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
This wires the existing sensor app into the new AP hosted interactive using the fake sensor.

The interactive state data is provided to both the runtime and report and the setter is provided to the runtime.  At this point though that interactive state is ignored pending discussion on how to save data.