### PR TITLE
Added heartbeat sensor reading [#181112413]

### DIFF
--- a/src/components/app.css
+++ b/src/components/app.css
@@ -325,6 +325,29 @@ button:active {
     background-color: var(--sage-dark-1);
 }
 
+.pause-heartbeat-button {
+    width: 106px;
+    height: 30px;
+    border-radius: 6px;
+    border: solid 2px var(--sage-dark-1);
+    background-color: var(--sage-light-2);
+    cursor: pointer;
+    transition-duration: .25s;
+    margin-left: 10px;
+}
+.pause-heartbeat-button:hover {
+    background-color: var(--sage);
+}
+.pause-heartbeat-button:active {
+    border: solid 2px var(--sage-dark-3);
+    background-color: var(--sage-dark-1);
+}
+.pause-heartbeat-button:disabled {
+    opacity: .35;
+    pointer-events: none;
+}
+
+
 /* Graphs */
 .graphs-panel {
     flex: 1 1;

--- a/src/components/graph-top-panel.tsx
+++ b/src/components/graph-top-panel.tsx
@@ -15,10 +15,11 @@ interface IGraphTopPanelProps {
   onRemoveSensor?:() => void;
   showRemoveSensor:boolean;
   assetsPath: string;
+  readingPaused: boolean;
 }
 
 export const GraphTopPanel: React.FC<IGraphTopPanelProps> = (props) => {
-  const { sensorSlot, onZeroSensor, onRemoveSensor, onSensorSelect } = props,
+  const { sensorSlot, onZeroSensor, onRemoveSensor, onSensorSelect, readingPaused } = props,
         { sensor } = sensorSlot,
         tareValue = sensor.tareValue || 0,
         sensorUnitStr = sensor.valueUnit || "";
@@ -41,7 +42,11 @@ export const GraphTopPanel: React.FC<IGraphTopPanelProps> = (props) => {
   };
 
   const sensorReading = () => {
-    const sensorValue = sensor && sensor.sensorValue;
+    if (readingPaused) {
+      return "Paused";
+    }
+
+    const sensorValue = sensor && (sensor.sensorHeartbeatValue || sensor.sensorValue);
     if ((sensorValue == null) || isNaN(sensorValue))
       return "";
 

--- a/src/models/fake-sensor-manager.ts
+++ b/src/models/fake-sensor-manager.ts
@@ -73,6 +73,8 @@ export class FakeSensorManager extends SensorManager {
         }
       };
       // this.sensorConfig = new SensorConfiguration(this.internalConfig);
+
+      this.supportsHeartbeat = true;
     }
 
     cloneInternalConfig() {
@@ -117,6 +119,19 @@ export class FakeSensorManager extends SensorManager {
       setTimeout(() => {
         this.onSensorCollectionStopped();
       });
+    }
+
+    requestHeartbeat(enabled: boolean): void {
+        this.manageHeartbeat(enabled, () => {
+          const temperatureValue = 17 + (Math.random() * 5);
+          const positionValue = 1 - (Math.random() * 2);
+          const config = this.cloneInternalConfig();
+
+          config.columns["101"].liveValue = temperatureValue.toString();
+          config.columns["102"].liveValue = positionValue.toString();
+
+          this.onSensorHeartbeat(new SensorConfiguration(config));
+        });
     }
 
     private sendValues(time: number, {temperatureValue, positionValue}: {temperatureValue: number, positionValue: number}) {

--- a/src/models/sensor-connector-manager.ts
+++ b/src/models/sensor-connector-manager.ts
@@ -74,6 +74,11 @@ export class SensorConnectorManager extends SensorManager {
       this.sensorConnector.requestStop();
     }
 
+    requestHeartbeat(enabled: boolean): void {
+        // FIXME: add heartbeat support when a device to test is available
+        console.error("Heartbeat not currently supported for this sensor");
+    }
+
     isAwake() {
       return this.sensorConnector.isConnected;
     }

--- a/src/models/sensor-manager.ts
+++ b/src/models/sensor-manager.ts
@@ -24,12 +24,16 @@ export interface ConnectableSensorManager {
 
 export abstract class SensorManager {
   supportsDualCollection: boolean;
+  supportsHeartbeat: boolean = false;
+
+  protected heartbeatInterval: number = 0;
 
   abstract startPolling() : void;
   abstract hasSensorData() : boolean;
   abstract requestStart() : void;
   abstract requestStop() : void;
   abstract isWirelessDevice() : boolean;
+  abstract requestHeartbeat(enabled: boolean) : void;
 
   isAwake() : boolean {
     return true;
@@ -92,6 +96,10 @@ export abstract class SensorManager {
     this.notifyListeners('onSensorData', newData);
   }
 
+  protected onSensorHeartbeat(sensorConfig: SensorConfiguration) {
+    this.notifyListeners('onSensorHeartbeat', sensorConfig);
+  }
+
   protected onSensorCollectionStopped() {
     this.notifyListeners('onSensorCollectionStopped');
   }
@@ -102,5 +110,12 @@ export abstract class SensorManager {
 
   protected onCommunicationError() {
     this.notifyListeners('onCommunicationError');
+  }
+
+  protected manageHeartbeat(enabled: boolean, callback: () => void) {
+    clearInterval(this.heartbeatInterval);
+    if (enabled) {
+      this.heartbeatInterval = window.setInterval(callback, 1000);
+    }
   }
 }

--- a/src/models/sensor-tag-manager.ts
+++ b/src/models/sensor-tag-manager.ts
@@ -320,6 +320,11 @@ export class SensorTagManager extends SensorManager implements ConnectableSensor
       this.stopRequested = true;
     }
 
+    requestHeartbeat(enabled: boolean): void {
+      // FIXME: add heartbeat support when a device to test is available
+      console.error("Heartbeat not currently supported for this sensor");
+    }
+
     async connectToDevice(device?: any): Promise<boolean> {
       if (device) {
         this.device = device;

--- a/src/models/sensor.ts
+++ b/src/models/sensor.ts
@@ -5,6 +5,7 @@ export class Sensor {
     columnID?:string;
     sensorPosition?:number; // index in received dataColumns array
     sensorValue?:number;
+    sensorHeartbeatValue?:number;  // sampled value at intervals when heartbeat is enabled
     dataChanged:boolean;
     tareValue:number;
     timeUnit:string;
@@ -28,8 +29,9 @@ export class Sensor {
     }
 
     zeroSensor() {
-        if (this.sensorValue != null) {
-            this.tareValue = this.sensorValue;
+        const currentValue = this.sensorValue || this.sensorHeartbeatValue;
+        if (currentValue != null) {
+            this.tareValue = currentValue;
         }
     }
 

--- a/src/models/thermoscope-manager.ts
+++ b/src/models/thermoscope-manager.ts
@@ -229,6 +229,11 @@ export class ThermoscopeManager extends SensorManager implements ConnectableSens
       this.stopRequested = true;
     }
 
+    requestHeartbeat(enabled: boolean): void {
+      // FIXME: add heartbeat support when a device to test is available
+      console.error("Heartbeat not currently supported for this sensor");
+    }
+
     async connectToDevice(): Promise<boolean> {
       // ask for a device
       this.device = await navigator.bluetooth.requestDevice({


### PR DESCRIPTION
This adds the start heartbeat support for the sensors so they immediately display pauseable sensor values when connected and not just when collecting data.

There are FIXME comments in the sensor connector, sensor tag and thermoscope managers to add heartbeat support when there are devices available to develop and test with.  For now those handlers show a console error and the device reading falls back to the sensor value.