### PR TITLE
181528797 Authors can hide pause button

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -522,7 +522,8 @@ export class App extends React.Component<AppProps, AppState> {
                 }
             });
         } catch (err) {
-            console.log("No wireless device selected");
+            console.error(err);
+            console.error("No wireless device selected");
         }
     }
 

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1148,7 +1148,7 @@ export class App extends React.Component<AppProps, AppState> {
         const pauseLabel = `${pauseHeartbeat ? "Start" : "Pause"} Reading`
         const pauseDisabled = this.state.collecting;
         const pauseClassName = `pause-heartbeat-button ${pauseDisabled ? "disabled" : ""}`;
-        const { enablePause } = this.props;;
+        const { enablePause } = this.props;
 
         const showPauseButton = sensorManager
             && sensorManager.supportsHeartbeat

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -244,7 +244,8 @@ export class App extends React.Component<AppProps, AppState> {
     }
 
     togglePauseHeartbeat() {
-        this.enableHeartbeat(!this.state.pauseHeartbeat);
+        // If we are paused, enable the heartbeat when pressed (unpausing)
+        this.enableHeartbeat(this.state.pauseHeartbeat);
     }
 
     passedSensorManager = () => {
@@ -559,6 +560,7 @@ export class App extends React.Component<AppProps, AppState> {
     }
 
     onSensorCollectionStopped() {
+        const { enablePause } = this.props;
         this.setState({
             collecting: false,
             statusMessage: this.messages["data_collection_stopped"]
@@ -569,7 +571,7 @@ export class App extends React.Component<AppProps, AppState> {
             sensorManager!.removeListener('onSensorCollectionStopped',
             this.onSensorCollectionStopped);
         }
-        if(!this.props.enablePause) {
+        if(!enablePause) {
             // If we don't have a pause button, then we need to start the
             // heartbeat monitor again, as the student has no way of doing
             // it themselves.
@@ -1146,10 +1148,12 @@ export class App extends React.Component<AppProps, AppState> {
         const pauseLabel = `${pauseHeartbeat ? "Start" : "Pause"} Reading`
         const pauseDisabled = this.state.collecting;
         const pauseClassName = `pause-heartbeat-button ${pauseDisabled ? "disabled" : ""}`;
+        const { enablePause } = this.props;;
+
         const showPauseButton = sensorManager
             && sensorManager.supportsHeartbeat
             && this.connectedSensorCount() > 0
-            && this.props.enablePause;
+            && enablePause;
 
         return (
             <div className="top-bar-right-controls">

--- a/src/interactive/authoring.tsx
+++ b/src/interactive/authoring.tsx
@@ -12,10 +12,12 @@ interface Props {
 
 export const AuthoringComponent: React.FC<Props> = ({initMessage}) => {
   const {authoredState, setAuthoredState} = useAuthoredState<IAuthoredState>();
-  const { singleReads, useFakeSensor, prompt, hint, sensorUnit, recordedData } = authoredState || defaultAuthoredState;
+  const { singleReads, enablePause, useFakeSensor, prompt, hint, sensorUnit, recordedData } = authoredState || defaultAuthoredState;
   const [parseError, setParseError] = React.useState<boolean>(false);
 
   const handlesingleReads = (e: React.ChangeEvent<HTMLInputElement>) => updateAuthoredState({singleReads: e.target.checked});
+
+  const handleEnablePause = (e: React.ChangeEvent<HTMLInputElement>) => updateAuthoredState({enablePause: e.target.checked});
 
   const updateAuthoredState = (newState: Partial<IAuthoredState>) => {
     setAuthoredState( prev => {
@@ -175,6 +177,8 @@ export const AuthoringComponent: React.FC<Props> = ({initMessage}) => {
       <fieldset>
         <legend>Data Acquisition</legend>
         <input type="checkbox" checked={singleReads} onChange={handlesingleReads} /> Single reads
+        <br />
+        <input type="checkbox" checked={enablePause} onChange={handleEnablePause} /> EnablePause
       </fieldset>
       { displayConfig() }
       { renderPrerecordedText() }

--- a/src/interactive/runtime.tsx
+++ b/src/interactive/runtime.tsx
@@ -23,6 +23,7 @@ export const RuntimeComponent: React.FC<Props> = ({initMessage}) => {
         interactiveHost="runtime"
         fakeSensor={authoredState.useFakeSensor}
         singleReads={authoredState.singleReads}
+        enablePause={authoredState.enablePause}
         maxGraphHeight={625}
         initialInteractiveState={initialInteractiveState}
         preRecordings ={recordedData ? [recordedData] : []}

--- a/src/interactive/types.ts
+++ b/src/interactive/types.ts
@@ -14,6 +14,7 @@ export interface SensorRecording {
 export interface IAuthoredState {
   useFakeSensor: boolean;
   singleReads: boolean;
+  enablePause: boolean;
   prompt: string;
   hint: string;
   sensorUnit?: Unit;
@@ -35,6 +36,7 @@ export interface IInteractiveSensorData {
 export const defaultAuthoredState: IAuthoredState = {
   useFakeSensor: false,
   singleReads: false,
+  enablePause: true,
   prompt: "",
   hint: "",
   sensorUnit: undefined

--- a/src/interactive/types.ts
+++ b/src/interactive/types.ts
@@ -36,7 +36,7 @@ export interface IInteractiveSensorData {
 export const defaultAuthoredState: IAuthoredState = {
   useFakeSensor: false,
   singleReads: false,
-  enablePause: true,
+  enablePause: false,
   prompt: "",
   hint: "",
   sensorUnit: undefined

--- a/src/models/sensor-gdx-manager.ts
+++ b/src/models/sensor-gdx-manager.ts
@@ -13,6 +13,9 @@ const POLLING_INTERVAL = 1000;
 // This is the nyquist frequency, and insures we have at least one sample for
 // each heartbeat.
 const SENSOR_HEARTBEAT_INTERVAL = HEARTBEAT_INTERVAL_MS / 2;
+
+// According to Vernier, the maximum sampling frequency got GDX-MD is 50hz
+// see: https://www.vernier.com/til/5
 const READ_DATA_INTERVAL = 50;
 
 export class SensorGDXManager extends SensorManager {
@@ -92,7 +95,7 @@ export class SensorGDXManager extends SensorManager {
           this.enabledSensors.forEach((sensor: any, index: number) => {
             const cNum = this.initialColumnNum + index;
             this.internalConfig.columns[cNum].liveValueTimeStamp = new Date();
-            this.internalConfig.columns[cNum].liveValue = sensor.value.toString();
+            this.internalConfig.columns[cNum].liveValue = sensor.value?.toString() || "none";
           });
           this.sendSensorConfig(false);
         }
@@ -161,7 +164,8 @@ export class SensorGDXManager extends SensorManager {
           const config = cloneDeep(this.internalConfig);
           this.enabledSensors.forEach((sensor: any, index: number) => {
             const cNum = this.initialColumnNum + index;
-            config.columns[cNum.toString()].liveValue = sensor.value.toString();
+            config.columns[cNum.toString()].liveValue =
+              sensor.value?.toString() || "none";
           });
           this.onSensorHeartbeat(new SensorConfiguration(config));
         }


### PR DESCRIPTION
## Authors can show / hide a pause button for sensor interactives

### What it does:
- [PT Story](https://www.pivotaltracker.com/story/show/181528797)
- Author has a UI to enable pausing of live data recording (heartbeat)
- By default sensor interactives do show pause buttons.
- By default, sensor component doesn't show a pause button (eg, when directly embedded in CODAP)
- When pause is pressed, the heartbeat and live-reading stops updating.
- When data is collected heartbeat is paused
- When data collection is done, heartbeat is resumed if there is no pause button (otherwise heartbeat remains paused)

### changes in this PR:
- additional error info when we get CORS error for web BT access failures.
- adds authoring interface / ui
- adds null check for when displaying heartbeat data

