### PR TITLE
182001006 – Support-Snapshots.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6212,6 +6212,11 @@
         "supports-color": "^8.0.0"
       }
     },
+    "jquery": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8176,6 +8181,11 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
       "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
       "dev": true
+    },
+    "shutterbug": {
+      "version": "1.3.3-pre",
+      "resolved": "https://registry.npmjs.org/shutterbug/-/shutterbug-1.3.3-pre.tgz",
+      "integrity": "sha512-nPRofWFz4Hn4kNpe0o0No+RP/fOZaMTxCXFJtXcCgboubamCS34Vsl0QG5jS73vf6ZNn9gduGkFypHJEEzl/Qw=="
     },
     "side-channel": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -49,12 +49,14 @@
     "d3-format": "^1.4.5",
     "dygraphs": "^2.1.0",
     "iframe-phone": "^1.3.1",
+    "jquery": "^3.6.0",
     "lodash": "^4.17.21",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-modal": "^3.14.4",
     "react-sizeme": "^3.0.2",
     "react-sparklines": "^1.7.0",
+    "shutterbug": "^1.3.3-pre",
     "text-encoding": "^0.7.0"
   },
   "devDependencies": {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -20,6 +20,7 @@ import { SensorGDXManager } from "../models/sensor-gdx-manager";
 import { IInteractiveState, SensorRecording } from "../interactive/types";
 import { SensorRecordingStore } from "../models/recording-store";
 import { PredictionState } from "./types";
+import { enableShutterbug, disableShutterbug } from "../js/shutterbug-support";
 
 import "./dialog.css";
 import "./app.css";
@@ -291,6 +292,11 @@ export class App extends React.Component<AppProps, AppState> {
                 console.error(`Unknown interactive state version: ${initialInteractiveState.version}`, {initialInteractiveState});
             }
         }
+        enableShutterbug("app-container");
+    }
+
+    componentWillUnmount() {
+        disableShutterbug();
     }
 
     connectCodap() {

--- a/src/js/shutterbug-support.ts
+++ b/src/js/shutterbug-support.ts
@@ -1,0 +1,18 @@
+import Shutterbug from "shutterbug";
+
+export function enableShutterbug(appClassName: string) {
+  Shutterbug.enable("." + appClassName);
+  Shutterbug.on("saycheese", beforeSnapshotHandler);
+}
+
+export function disableShutterbug() {
+  Shutterbug.disable();
+  Shutterbug.off("saycheese", beforeSnapshotHandler);
+}
+
+function beforeSnapshotHandler() {
+  // This a no-op for now, because our canvases are doing the right thing.
+  // stacking PNGs in the correct order. If this stops working for some reason,
+  // we might need to manually composite the PNGs.
+  console.info("Shutterbug: before snapshot -- Nothing to do FTM.");
+}

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,3 +1,4 @@
 declare module 'react-modal';
 declare module 'react-sizeme';
 declare module '@vernier/godirect';
+declare module 'shutterbug';


### PR DESCRIPTION

## Add Snapshot support to sensor interactive:
- Add Shutterbug and JQuery to package.json
- Enable shutterbug on our main app component
- Add `saycheese` handler (no-op for now)

**NB:** running `npm install --save shutterbug` installed a `pre-` release tag of shutterbug. This is the one currently listed at NPM as current: https://www.npmjs.com/package/shutterbug – While I find that puzzling, I don't think it's a problem.

## PT Story:
[#182001006]
https://www.pivotaltracker.com/story/show/182001006