### PR TITLE
Add support for GoDirect EKG sensor (PT-186280507)

### DIFF
--- a/src/components/sensor-graph.tsx
+++ b/src/components/sensor-graph.tsx
@@ -41,19 +41,36 @@ interface SensorGraphState {
     xMax:number;
 }
 
+
+function getQueryParameterOverride(param: string, sensorUnit?: string): number | null {
+  if (!sensorUnit) {
+    return null;
+  }
+  const urlParams = new URLSearchParams(window.location.search);
+  const key = `${sensorUnit}${param}Override`;
+  const override = urlParams.get(key);
+  if (override != null) {
+    const overrideValue = parseFloat(override);
+    if (!isNaN(overrideValue)) {
+      return overrideValue;
+    }
+  }
+  return null;
+}
+
 export default class SensorGraph extends React.Component<SensorGraphProps, SensorGraphState> {
 
     sensor:Sensor;
     lastDataIndex:number = 0;
 
     constructor(props:SensorGraphProps) {
-        super(props);
-        this.state = {
-            xMin: this.props.xStart,
-            xMax: this.props.xEnd,
-            yMin: this.props.preRecording?.min ?? 0,
-            yMax: this.props.preRecording?.max ?? 100,
-        };
+      super(props);
+      this.state = {
+          xMin: this.props.xStart,
+          xMax: this.props.xEnd,
+          yMin: this.props.preRecording?.min ?? 0,
+          yMax: this.props.preRecording?.max ?? 100,
+      };
     }
 
     componentDidMount(){
@@ -163,7 +180,7 @@ export default class SensorGraph extends React.Component<SensorGraphProps, Senso
       } else {
         let processedData = [[0, 0]];
         for (let i = 0; i < data.length; i++) {
-          // Single read bar graphs need to include values for time elapsed 
+          // Single read bar graphs need to include values for time elapsed
           // which will be shown in the x-axis labels.
           const timeSinceLastRead = i > 0 ? data[i][0] : 0;
           processedData.push([i + 1, data[i][1], timeSinceLastRead]);
@@ -201,10 +218,19 @@ export default class SensorGraph extends React.Component<SensorGraphProps, Senso
     }
 
     renderGraph(graphWidth:number|null) {
-        const { sensorRecording } = this.props;
+        const { sensorRecording, preRecording } = this.props;
         const { yMin, yMax, xMin, xMax } = this.state;
 
         const labels = [] as string[];
+
+        let yMinOverride:number|null = null;
+        let yMaxOverride:number|null = null;
+        if (sensorRecording || preRecording) {
+          const source = sensorRecording || preRecording;
+          const sensorUnit = source?.displayUnits || source?.unit;
+          yMinOverride = getQueryParameterOverride("YMin", sensorUnit);
+          yMaxOverride = getQueryParameterOverride("YMax", sensorUnit);
+        }
 
         const data = this.processData();
         return (
@@ -218,8 +244,8 @@ export default class SensorGraph extends React.Component<SensorGraphProps, Senso
                 resetScaleF={this.handleResetScale}
                 xMin={xMin}
                 xMax={xMax}
-                yMin={yMin}
-                yMax={yMax}
+                yMin={yMinOverride ?? yMin}
+                yMax={yMaxOverride ?? yMax}
                 // TODO: figure out default precision
                 valuePrecision={sensorRecording?.precision || 2}
                 xLabel={this.xLabel()}

--- a/src/components/sensor-graph.tsx
+++ b/src/components/sensor-graph.tsx
@@ -41,23 +41,6 @@ interface SensorGraphState {
     xMax:number;
 }
 
-
-function getQueryParameterOverride(param: string, sensorUnit?: string): number | null {
-  if (!sensorUnit) {
-    return null;
-  }
-  const urlParams = new URLSearchParams(window.location.search);
-  const key = `${sensorUnit}${param}Override`;
-  const override = urlParams.get(key);
-  if (override != null) {
-    const overrideValue = parseFloat(override);
-    if (!isNaN(overrideValue)) {
-      return overrideValue;
-    }
-  }
-  return null;
-}
-
 export default class SensorGraph extends React.Component<SensorGraphProps, SensorGraphState> {
 
     sensor:Sensor;
@@ -218,19 +201,10 @@ export default class SensorGraph extends React.Component<SensorGraphProps, Senso
     }
 
     renderGraph(graphWidth:number|null) {
-        const { sensorRecording, preRecording } = this.props;
+        const { sensorRecording } = this.props;
         const { yMin, yMax, xMin, xMax } = this.state;
 
         const labels = [] as string[];
-
-        let yMinOverride:number|null = null;
-        let yMaxOverride:number|null = null;
-        if (sensorRecording || preRecording) {
-          const source = sensorRecording || preRecording;
-          const sensorUnit = source?.displayUnits || source?.unit;
-          yMinOverride = getQueryParameterOverride("YMin", sensorUnit);
-          yMaxOverride = getQueryParameterOverride("YMax", sensorUnit);
-        }
 
         const data = this.processData();
         return (
@@ -244,8 +218,8 @@ export default class SensorGraph extends React.Component<SensorGraphProps, Senso
                 resetScaleF={this.handleResetScale}
                 xMin={xMin}
                 xMax={xMax}
-                yMin={yMinOverride ?? yMin}
-                yMax={yMaxOverride ?? yMax}
+                yMin={yMin}
+                yMax={yMax}
                 // TODO: figure out default precision
                 valuePrecision={sensorRecording?.precision || 2}
                 xLabel={this.xLabel()}

--- a/src/models/sensor-definitions.ts
+++ b/src/models/sensor-definitions.ts
@@ -132,8 +132,8 @@ export const SensorStrings:ISensorStrings = {
       "station_pressure": "Station Pressure",
       "barometric_pressure": "Barometric Pressure",
       "voltage": "Voltage",
-      "EMG": "EMG",
-      "EMGR": "EMG Rectified",
+      "EKG": "EKG",
+      "heart_rate": "Heart Rate"
     },
     "names": {
       "sensor": "sensor",
@@ -190,8 +190,7 @@ export const SensorStrings:ISensorStrings = {
       "absolute_humidity": "Absolute Humidity",
       "station_pressure": "Station Pressure",
       "barometric_pressure": "Barometric Pressure",
-      "EMG": "EMG",
-      "EMGR": "EMG Rectified"
+      "EKG": "EKG",
     }
 };
 
@@ -769,31 +768,22 @@ export const SensorDefinitions:ISensorDefinitions = {
     "maxReading":  10000,
     "displayUnits": "m"
   },
-  "mV_EMG": {
-    "sensorName": i18n.t("sensor.names.EMG"),
-    "measurementName": i18n.t("sensor.measurements.EMG"),
-    "measurementType": "EMG",
+  "mV_EKG": {
+    "sensorName": i18n.t("sensor.names.EKG"),
+    "measurementName": i18n.t("sensor.measurements.EKG"),
+    "measurementType": "EKG",
     "tareable": false,
-    "minReading": -4,
-    "maxReading":  4,
+    "minReading": -0.4,
+    "maxReading":  1,
     "displayUnits": "mV"
   },
-  "mV_EMGR": {
-    "sensorName": i18n.t("sensor.names.EMGR"),
-    "measurementName": i18n.t("sensor.measurements.EMGR"),
-    "measurementType": "EMGR",
+  "bpm": {
+    "sensorName": i18n.t("sensor.names.heart_rate"),
+    "measurementName": i18n.t("sensor.measurements.heart_rate"),
+    "measurementType": "Heart Rate",
     "tareable": false,
     "minReading": 0,
-    "maxReading":  4,
-    "displayUnits": "mV"
+    "maxReading":  150,
+    "displayUnits": "bpm"
   },
-  "mV_V": {
-    "sensorName": i18n.t("sensor.names.voltage"),
-    "measurementName": i18n.t("sensor.measurements.voltage"),
-    "measurementType": "voltage",
-    "tareable": false,
-    "minReading": -4,
-    "maxReading":  4,
-    "displayUnits": "mV"
-  }
 } as const;

--- a/src/models/sensor-definitions.ts
+++ b/src/models/sensor-definitions.ts
@@ -130,7 +130,10 @@ export const SensorStrings:ISensorStrings = {
       "dew_point": "Dew Point",
       "absolute_humidity": "Absolute Humidity",
       "station_pressure": "Station Pressure",
-      "barometric_pressure": "Barometric Pressure"
+      "barometric_pressure": "Barometric Pressure",
+      "voltage": "Voltage",
+      "EMG": "EMG",
+      "EMGR": "EMG Rectified",
     },
     "names": {
       "sensor": "sensor",
@@ -186,7 +189,9 @@ export const SensorStrings:ISensorStrings = {
       "dew_point": "Dew Point",
       "absolute_humidity": "Absolute Humidity",
       "station_pressure": "Station Pressure",
-      "barometric_pressure": "Barometric Pressure"
+      "barometric_pressure": "Barometric Pressure",
+      "EMG": "EMG",
+      "EMGR": "EMG Rectified"
     }
 };
 
@@ -763,5 +768,32 @@ export const SensorDefinitions:ISensorDefinitions = {
     "minReading": -300,
     "maxReading":  10000,
     "displayUnits": "m"
+  },
+  "mV_EMG": {
+    "sensorName": i18n.t("sensor.names.EMG"),
+    "measurementName": i18n.t("sensor.measurements.EMG"),
+    "measurementType": "EMG",
+    "tareable": false,
+    "minReading": -4,
+    "maxReading":  4,
+    "displayUnits": "mV"
+  },
+  "mV_EMGR": {
+    "sensorName": i18n.t("sensor.names.EMGR"),
+    "measurementName": i18n.t("sensor.measurements.EMGR"),
+    "measurementType": "EMGR",
+    "tareable": false,
+    "minReading": 0,
+    "maxReading":  4,
+    "displayUnits": "mV"
+  },
+  "mV_V": {
+    "sensorName": i18n.t("sensor.names.voltage"),
+    "measurementName": i18n.t("sensor.measurements.voltage"),
+    "measurementType": "voltage",
+    "tareable": false,
+    "minReading": -4,
+    "maxReading":  4,
+    "displayUnits": "mV"
   }
 } as const;

--- a/src/models/sensor-gdx-manager.ts
+++ b/src/models/sensor-gdx-manager.ts
@@ -196,7 +196,6 @@ export class SensorGDXManager extends SensorManager {
     }
 
     getSensorUnits(sensor: any){
-      console.log({sensor});
       if (Object.keys(SpecialMeasurementUnits).includes(sensor.name)){
         return SpecialMeasurementUnits[sensor.name];
       } else {

--- a/src/models/sensor-gdx-manager.ts
+++ b/src/models/sensor-gdx-manager.ts
@@ -220,7 +220,7 @@ export class SensorGDXManager extends SensorManager {
 
       // set a new reading interval for live calibration readings
       // can be much slower than capture interval.
-      this.gdxDevice.start(HEARTBEAT_INTERVAL_MS);
+      this.gdxDevice.start(SENSOR_HEARTBEAT_INTERVAL);
 
       // turn on any default sensors
       this.gdxDevice.enableDefaultSensors();

--- a/src/models/sensor-gdx-manager.ts
+++ b/src/models/sensor-gdx-manager.ts
@@ -30,7 +30,10 @@ export const SpecialMeasurementUnits: IStringMap = {
   "Relative Humidity": "%RH",
   "Station Pressure": "mbar_SP",
   "Barometric Pressure": "mbar_BP",
-  "Altitude": "m_AL"
+  "Altitude": "m_AL",
+  "EMG": "mV_EMG",
+  "EMG Rectified": "mV_EMGR",
+  "Voltage": "mV_V",
 }
 
 export class SensorGDXManager extends SensorManager {
@@ -193,6 +196,7 @@ export class SensorGDXManager extends SensorManager {
     }
 
     getSensorUnits(sensor: any){
+      console.log({sensor});
       if (Object.keys(SpecialMeasurementUnits).includes(sensor.name)){
         return SpecialMeasurementUnits[sensor.name];
       } else {


### PR DESCRIPTION
Hi Scott, Doug and I met yesterday to work on this [this](https://www.pivotaltracker.com/story/show/186280507) story about adding support for the EKG sensor. The sensor already connected to Sensor Interactive fine, but the graph `yMin` and `yMax` values were too large, and the names for the sensors were incorrect. This was because the sensor has a unit of mV, and mV has the following definition in `sensor-definitions.ts`:

<img width="467" alt="Screen Shot 2023-10-26 at 9 15 57 AM" src="https://github.com/concord-consortium/sensor-interactive/assets/89816272/07e51ff5-52ed-4c1c-82b9-40245ea569ac">

Initially, Doug and I decided to add query parameters so that we can specify in activities using this sensor what the graph `yMin` and `yMax` values should be. But after looking at this some more this morning, I thought this wouldn't be the best approach because 1.) It doesn't fix the incorrect labels in the dropdown menu / on the graph and 2.) It might interfere with a case in which a second sensor graph is added. 

I realized that we had faced some similar issues previously, with the same units being used for different sensors with different definitions and ranges, and gotten around it by using this `SpecialMeasurementUnits` object to check for unique sensor names that we wanted to accommodate. So I updated that object to include these new sensor names, and added new definitions for the special units to the `sensor-definitions` file. 

Curious to get your feedback on either of these approaches. 


