### PR TITLE
Fix wired sensor data disappearing. (PT-187241956)

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -109,8 +109,9 @@ export interface AppState {
     newSensorSelection: ISensorSelection | null;
   }
 
-function newSensorFromDataColumn(dataColumn:SensorConfigColumnInfo) {
-    let newSensor = new Sensor();
+function newSensorFromDataColumn(dataColumn:SensorConfigColumnInfo, sensor?: Sensor) {
+    const reuseID = sensor?.valueUnit === dataColumn.units && sensor.sensorPosition === dataColumn.position;
+    const newSensor = new Sensor(reuseID ? sensor.id : undefined);
     newSensor.columnID = dataColumn.id;
     newSensor.sensorPosition = dataColumn.position;
     newSensor.valueUnit = dataColumn.units;
@@ -125,9 +126,10 @@ function matchSensorsToDataColumns(slots:SensorSlot[], dataColumns:SensorConfigC
         matched.forEach((sensor:Sensor|null, index) => {
             let found;
             if (!matched[index]) {
-                found = find(columns, (c) => test(c, slots[index].sensor));
+              const currentSensor = slots[index].sensor
+                found = find(columns, (c) => test(c, currentSensor));
                 if (found) {
-                    matched[index] = newSensorFromDataColumn(found);
+                    matched[index] = newSensorFromDataColumn(found, currentSensor);
                     // remove matched column so it can't be matched again
                     pull(columns, found);
                 }

--- a/src/examples/fake-sensor-bar-prediction-prerecorded.tsx
+++ b/src/examples/fake-sensor-bar-prediction-prerecorded.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "degC",
   precision: 2,
   name: 'Temperature',

--- a/src/examples/fake-sensor-bar-preload-position-pause-ondemand.tsx
+++ b/src/examples/fake-sensor-bar-preload-position-pause-ondemand.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "m",
   precision: 2,
   name: 'Position',

--- a/src/examples/fake-sensor-bar-preload-position.tsx
+++ b/src/examples/fake-sensor-bar-preload-position.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "m",
   precision: 2,
   name: 'Position',

--- a/src/examples/fake-sensor-bar-preload-predict-position-pause-ondemand.tsx
+++ b/src/examples/fake-sensor-bar-preload-predict-position-pause-ondemand.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "m",
   precision: 2,
   name: 'Position',

--- a/src/examples/fake-sensor-bar-preload-predict-position.tsx
+++ b/src/examples/fake-sensor-bar-preload-predict-position.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "m",
   precision: 2,
   name: 'Position',

--- a/src/examples/fake-sensor-bar-preload-predict-temperature-pause-ondemand.tsx
+++ b/src/examples/fake-sensor-bar-preload-predict-temperature-pause-ondemand.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "degC",
   precision: 2,
   name: 'Temperature',

--- a/src/examples/fake-sensor-bar-preload-predict-temperature.tsx
+++ b/src/examples/fake-sensor-bar-preload-predict-temperature.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "degC",
   precision: 2,
   name: 'Temperature',

--- a/src/examples/fake-sensor-bar-preload-temperature-pause-ondemand.tsx
+++ b/src/examples/fake-sensor-bar-preload-temperature-pause-ondemand.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "degC",
   precision: 2,
   name: 'Temperature',

--- a/src/examples/fake-sensor-bar-preload-temperature.tsx
+++ b/src/examples/fake-sensor-bar-preload-temperature.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "degC",
   precision: 2,
   name: 'Temperature',

--- a/src/examples/fake-sensor-bar-prerecorded-ondemand.tsx
+++ b/src/examples/fake-sensor-bar-prerecorded-ondemand.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "degC",
   precision: 2,
   name: 'Temperature',

--- a/src/examples/fake-sensor-bar-prerecorded.tsx
+++ b/src/examples/fake-sensor-bar-prerecorded.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "degC",
   precision: 2,
   name: 'Temperature',

--- a/src/examples/fake-sensor-line-prediction-prerecorded.tsx
+++ b/src/examples/fake-sensor-line-prediction-prerecorded.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "degC",
   precision: 2,
   name: 'Temperature',

--- a/src/examples/fake-sensor-line-preload-position-pause-ondemand.tsx
+++ b/src/examples/fake-sensor-line-preload-position-pause-ondemand.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "m",
   precision: 2,
   name: 'Position',

--- a/src/examples/fake-sensor-line-preload-position.tsx
+++ b/src/examples/fake-sensor-line-preload-position.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "m",
   precision: 2,
   name: 'Position',

--- a/src/examples/fake-sensor-line-preload-predict-position-pause-ondemand.tsx
+++ b/src/examples/fake-sensor-line-preload-predict-position-pause-ondemand.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "m",
   precision: 2,
   name: 'Position',

--- a/src/examples/fake-sensor-line-preload-predict-position.tsx
+++ b/src/examples/fake-sensor-line-preload-predict-position.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "m",
   precision: 2,
   name: 'Position',

--- a/src/examples/fake-sensor-line-preload-predict-temperature-pause-ondemand.tsx
+++ b/src/examples/fake-sensor-line-preload-predict-temperature-pause-ondemand.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "degC",
   precision: 2,
   name: 'Temperature',

--- a/src/examples/fake-sensor-line-preload-predict-temperature.tsx
+++ b/src/examples/fake-sensor-line-preload-predict-temperature.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "degC",
   precision: 2,
   name: 'Temperature',

--- a/src/examples/fake-sensor-line-preload-temperature-pause-ondemand.tsx
+++ b/src/examples/fake-sensor-line-preload-temperature-pause-ondemand.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "degC",
   precision: 2,
   name: 'Temperature',

--- a/src/examples/fake-sensor-line-preload-temperature.tsx
+++ b/src/examples/fake-sensor-line-preload-temperature.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "degC",
   precision: 2,
   name: 'Temperature',

--- a/src/examples/fake-sensor-line-prerecorded-ondemand.tsx
+++ b/src/examples/fake-sensor-line-prerecorded-ondemand.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "degC",
   precision: 2,
   name: 'Temperature',

--- a/src/examples/fake-sensor-line-prerecorded.tsx
+++ b/src/examples/fake-sensor-line-prerecorded.tsx
@@ -5,6 +5,7 @@ import { SensorRecording } from "../interactive/types";
 
 const recording: SensorRecording = {
   columnID: "100",
+  sensorID: 0,
   unit: "degC",
   precision: 2,
   name: 'Temperature',

--- a/src/interactive/authoring.tsx
+++ b/src/interactive/authoring.tsx
@@ -179,6 +179,7 @@ export const AuthoringComponent: React.FC<Props> = ({initMessage}) => {
       const tareValue = 0;
       const a: SensorRecording = {
         data,
+        sensorID: -1,
         precision,
         columnID,
         sensorPosition,

--- a/src/interactive/types.ts
+++ b/src/interactive/types.ts
@@ -1,5 +1,6 @@
 export interface SensorRecording {
   columnID: string;
+  sensorID: number;
   unit: string;
   precision: number;
   name: string;

--- a/src/models/recording-store.ts
+++ b/src/models/recording-store.ts
@@ -22,6 +22,7 @@ export class SensorRecordingStore {
 
       let sensorRecording:  SensorRecording = {
         columnID,
+        sensorID: sensor.id,
         unit: sensor.valueUnit,
         precision: sensor.sensorPrecision(),
         name: sensorDefinition.measurementName,
@@ -58,8 +59,8 @@ export class SensorRecordingStore {
             if (index < numSensors) {
                 let sensorRecording: SensorRecording;
                 const sensor = sensorSlot.sensor;
-                const columnID = sensor.columnID!;
-                const index = this.sensorRecordings.findIndex(s => s.columnID === columnID);
+                const sensorID = sensor.id;
+                const index = this.sensorRecordings.findIndex(recording => recording.sensorID === sensorID);
                 if (index !== -1) {
                     sensorRecording = this.sensorRecordings[index];
                     // remove sensor recording to guard against adding the same object twice to the array when two sensor slots have the same column id

--- a/src/models/sensor.ts
+++ b/src/models/sensor.ts
@@ -1,8 +1,11 @@
 import { ISensorDefinition } from "./sensor-definitions";
 import { Format } from "../utils/format";
 
+let nextSensorId = 0;
+
 export class Sensor {
     columnID?:string;
+    id:number;
     sensorPosition?:number; // index in received dataColumns array
     sensorValue?:number;
     sensorHeartbeatValue?:number;  // sampled value at intervals when heartbeat is enabled
@@ -12,8 +15,9 @@ export class Sensor {
     valueUnit:string;
     definition:ISensorDefinition;
 
-    constructor() {
+    constructor(id?: number) {
         this.tareValue = 0;
+        this.id = id === undefined ? nextSensorId++ : id;
         this.definition = {
             sensorName:"",
             measurementName:"",


### PR DESCRIPTION
This PR fixes the wired sensor data disappearing. What was happening at the end of a run was that the sensor connector application was emitting an event that was causing a new sensor to be created, which would then make the old data disappear. We've added a sensor id so that when a new sensor is created, we can match it up with the old existing sensor and keep the data we want.