### PR TITLE
Autoscale considers all data when determining its fit. (PT-#187307933)

### DIFF
--- a/src/components/app.css
+++ b/src/components/app.css
@@ -437,11 +437,30 @@ button:disabled:hover {
     width: 24px;
     height: 24px;
     cursor: pointer;
-    transition-duration: .25s;
+    border-radius: 5px;
 }
-.graph-rescale-button:hover .icon {
+
+.graph-rescale-button.disabled {
+    pointer-events: none;
+    cursor: default;
+}
+
+.graph-rescale-button.selected {
+  background-color: var(--cc-teal-dark-1);
+}
+
+.icon.rescale.selected {
+  fill: white;
+}
+
+.graph-rescale-button:hover .icon{
     fill: #8f8f8f;
 }
+
+.graph-rescale-button:hover .icon.selected {
+  fill: var(--cc-teal-light-5);
+}
+
 .graph-rescale-button:active .icon {
     fill: var(--graph-axes);
 }

--- a/src/components/graph.tsx
+++ b/src/components/graph.tsx
@@ -352,8 +352,9 @@ export class Graph extends React.Component<GraphProps, GraphState> {
 
         newState.data = data;
         newState.dataLength = data.length;
-        newState.yAxisFix = Format.getAxisFix('y', this.props.yMax - this.props.yMin, nextProps.height);
-        newState.xAxisFix = Format.getAxisFix('x', this.props.xMax - this.props.xMin, nextProps.width);
+
+        newState.yAxisFix = Format.getAxisFix('y', nextProps.yMax - nextProps.yMin, nextProps.height);
+        newState.xAxisFix = Format.getAxisFix('x', nextProps.xMax - nextProps.xMin, nextProps.width);
 
         this.setState(newState);
     }

--- a/src/components/graph.tsx
+++ b/src/components/graph.tsx
@@ -352,6 +352,8 @@ export class Graph extends React.Component<GraphProps, GraphState> {
 
         newState.data = data;
         newState.dataLength = data.length;
+        newState.yAxisFix = Format.getAxisFix('y', this.props.yMax - this.props.yMin, nextProps.height);
+        newState.xAxisFix = Format.getAxisFix('x', this.props.xMax - this.props.xMin, nextProps.width);
 
         this.setState(newState);
     }

--- a/src/components/graphs-panel.tsx
+++ b/src/components/graphs-panel.tsx
@@ -36,8 +36,9 @@ export const GraphsPanel: React.FC<IGraphsPanelProps> = (props) => {
     preRecording?: SensorRecording,
     title:string,
     isSingletonGraph:boolean,
-    isLastGraph:boolean}) {
-    const {sensorRecording, preRecording, title, isSingletonGraph, isLastGraph} = options,
+    isLastGraph:boolean,
+    disabled:boolean}) {
+    const {sensorRecording, preRecording, title, isSingletonGraph, isLastGraph, disabled} = options,
           // if single graph, subtract height of top bar; otherwise top bar is doubled, subtract two times
           availableHeight = isSingletonGraph ? props.maxHeight - 46 : props.maxHeight - 92,
           singleGraphHeight = availableHeight,
@@ -75,6 +76,7 @@ export const GraphsPanel: React.FC<IGraphsPanelProps> = (props) => {
         useAuthoredData={props.useAuthoredData}
         overrideAxes={props.overrideAxes}
         authoredMinMax={props.authoredMinMax}
+        disabled={disabled}
       />
     );
   }
@@ -100,9 +102,9 @@ export const GraphsPanel: React.FC<IGraphsPanelProps> = (props) => {
 
   return (
       <div className={classes} style={style}>
-        {renderGraph({sensorRecording: sensorRecordings[0], preRecording: preRecordings && preRecordings[0], title: "graph1", isSingletonGraph: !showSecondGraph, isLastGraph: !showSecondGraph})}
+        {renderGraph({sensorRecording: sensorRecordings[0], preRecording: preRecordings && preRecordings[0], title: "graph1", isSingletonGraph: !showSecondGraph, isLastGraph: !showSecondGraph, disabled})}
         {showSecondGraph
-            ? renderGraph({sensorRecording: sensorRecordings[1], title: "graph2", isSingletonGraph: false, isLastGraph: true})
+            ? renderGraph({sensorRecording: sensorRecordings[1], title: "graph2", isSingletonGraph: false, isLastGraph: true, disabled})
             : null}
       </div>
     );


### PR DESCRIPTION
This PR changes the logic of the autoscale button to accommodate the following desired behaviors:
- graph begins with default axes, whether they are authored or set by the sensor
- scale toggle button can be pressed at any time before, during prediction, during or after measurement. 
- toggle will always consider ALL data when determining it's fit all extent
- when the toggle switches to 'default axes' it will respect authored limits if any