### PR TITLE
Fix Authoring Sensor Interactive Bugs (PT-187320998)

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -212,6 +212,10 @@ class AppContainer extends React.Component<AppProps, AppState> {
                        ? MAX_BAR_CHART_SAMPLES + 1
                        : DEFAULT_RUN_LENGTH + 0.01; // without the .01, last tick number sometimes fails to display
 
+        const runLength = props.authoredMinMax?.authoredXMax && props.overrideAxes
+                            ? props.authoredMinMax?.authoredXMax
+                            : DEFAULT_RUN_LENGTH
+
         this.state = {
             sensorManager:this.passedSensorManager(),
             sensorConfig:null,
@@ -222,7 +226,7 @@ class AppContainer extends React.Component<AppProps, AppState> {
             collecting:false,
             predictionState: props.requirePrediction ? "pending" : "not-required",
             prediction: props.displayType === "bar" && props.requirePrediction ? defaultBarGraphPrediction : [],
-            runLength: this.props.authoredMinMax?.authoredXMax ? this.props.authoredMinMax?.authoredXMax : DEFAULT_RUN_LENGTH,
+            runLength,
             xStart: 0,
             xEnd,
             timeUnit:"",
@@ -1453,6 +1457,16 @@ class AppContainer extends React.Component<AppProps, AppState> {
       this.setState({warnClearPrediction: true});
     }
 
+    getDurationOptions () {
+      const defaultOptions = [1, 5, 10, 15, 20, 30, 45, 60, 300, 600, 900, 1200, 1800];
+      const {overrideAxes, authoredMinMax} = this.props;
+      if (overrideAxes && authoredMinMax?.authoredXMax && defaultOptions.indexOf(authoredMinMax.authoredXMax) === -1) {
+        defaultOptions.push(authoredMinMax.authoredXMax);
+        defaultOptions.sort((a, b) => a - b);
+      }
+      return defaultOptions;
+    }
+
     render() {
         const { interactiveHost, useSensors, requirePrediction, fakeSensor, size } = this.props;
         const { sensorConfig, sensorManager, sensorRecordings } = this.state;
@@ -1472,6 +1486,7 @@ class AppContainer extends React.Component<AppProps, AppState> {
             ? [...this.props.preRecordings]
             : [];
 
+        const durationOptions = this.getDurationOptions();
         const maxGraphHeight = size.height - this.state.promptHeight - this.state.topBarHeight - 60; // 60 is the height of control panel, set in CSS
         return (
             <div className="app-container">
@@ -1632,7 +1647,7 @@ class AppContainer extends React.Component<AppProps, AppState> {
                     dataChanged={this.state.dataChanged}
                     duration={this.state.runLength}
                     durationUnit="s"
-                    durationOptions={[1, 5, 10, 15, 20, 30, 45, 60, 300, 600, 900, 1200, 1800]}
+                    durationOptions={durationOptions}
                     embedInCodapUrl={codapURL}
                     onDurationChange={this.setXZoomState}
                     onStartConnecting={this.startConnecting}

--- a/src/interactive/authoring.tsx
+++ b/src/interactive/authoring.tsx
@@ -25,11 +25,8 @@ export const AuthoringComponent: React.FC<Props> = ({initMessage}) => {
     recordedData, usePrediction, useAuthoredData, useSensors, displayType, overrideAxes,
     authoredMinMax } = authoredState || defaultAuthoredState;
   const {authoredXMin, authoredXMax, authoredYMin, authoredYMax} = authoredMinMax || {};
-
   const [parseError, setParseError] = React.useState<boolean>(false);
   const [minMax, setMinMax] = React.useState<IYMinMax>({xMin: "0", xMax: "0", yMin: "0", yMax: "0"});
-  const [disableUnits, setDisableUnits] = React.useState<boolean>(true);
-
 
   React.useEffect(() => {
     const { xMin, xMax, yMin, yMax } = minMax;
@@ -48,15 +45,6 @@ export const AuthoringComponent: React.FC<Props> = ({initMessage}) => {
     }
     setMinMax(newMinMax);
   }, [authoredXMin, authoredXMax, authoredYMin, authoredYMax]);
-
-  React.useEffect(() => {
-    if (usePrediction || useAuthoredData || overrideAxes) {
-      setDisableUnits(false);
-    } else {
-      setDisableUnits(true);
-      updateAuthoredState({sensorUnit: undefined});
-    }
-  }, [usePrediction, useAuthoredData, overrideAxes])
 
   const handlesingleReads = (e: React.ChangeEvent<HTMLInputElement>) => updateAuthoredState({singleReads: e.target.checked});
 
@@ -231,6 +219,7 @@ export const AuthoringComponent: React.FC<Props> = ({initMessage}) => {
     });
   };
 
+  const disableUnits = !useAuthoredData && !usePrediction && !overrideAxes;
   const unitOptionTags = disableUnits
    ? [
         <option
@@ -437,7 +426,7 @@ export const AuthoringComponent: React.FC<Props> = ({initMessage}) => {
           <select
             value={disableUnits ? "none" : sensorUnit}
             onChange={handleUnitChange}
-            disabled={!(useAuthoredData || usePrediction || overrideAxes)}>
+            disabled={disableUnits}>
             {unitOptionTags}
           </select>
         </div>

--- a/src/interactive/authoring.tsx
+++ b/src/interactive/authoring.tsx
@@ -12,10 +12,10 @@ interface Props {
 }
 
 interface IYMinMax {
-  xMin: number;
-  xMax: number;
-  yMin: number;
-  yMax: number;
+  xMin: string;
+  xMax: string;
+  yMin: string;
+  yMax: string;
 }
 
 export const AuthoringComponent: React.FC<Props> = ({initMessage}) => {
@@ -27,24 +27,24 @@ export const AuthoringComponent: React.FC<Props> = ({initMessage}) => {
   const {authoredXMin, authoredXMax, authoredYMin, authoredYMax} = authoredMinMax || {};
 
   const [parseError, setParseError] = React.useState<boolean>(false);
-  const [minMax, setMinMax] = React.useState<IYMinMax>({xMin: 0, xMax: 0, yMin: 0, yMax: 0});
+  const [minMax, setMinMax] = React.useState<IYMinMax>({xMin: "0", xMax: "0", yMin: "0", yMax: "0"});
   const [disableUnits, setDisableUnits] = React.useState<boolean>(true);
 
 
   React.useEffect(() => {
     const { xMin, xMax, yMin, yMax } = minMax;
     const newMinMax: IYMinMax = {...minMax};
-    if (authoredXMin !== undefined && authoredXMin!== xMin) {
-      newMinMax.xMin = authoredXMin;
+    if (authoredXMin !== undefined && authoredXMin!== Number(xMin)) {
+      newMinMax.xMin = `${authoredXMin}`;
     }
-    if (authoredXMax !== undefined && authoredXMax !== xMax) {
-      newMinMax.xMax = authoredXMax;
+    if (authoredXMax !== undefined && authoredXMax !== Number(xMax)) {
+      newMinMax.xMax = `${authoredXMax}`;
     }
-    if (authoredYMin !== undefined && authoredYMin !== yMin) {
-      newMinMax.yMin = authoredYMin;
+    if (authoredYMin !== undefined && authoredYMin !== Number(yMin)) {
+      newMinMax.yMin = `${authoredYMin}`;
     }
-    if (authoredYMax !== undefined && authoredYMax !== yMax) {
-      newMinMax.yMax = authoredYMax;
+    if (authoredYMax !== undefined && authoredYMax !== Number(yMax)) {
+      newMinMax.yMax = `${authoredYMax}`;
     }
     setMinMax(newMinMax);
   }, [authoredXMin, authoredXMax, authoredYMin, authoredYMax]);
@@ -113,21 +113,40 @@ export const AuthoringComponent: React.FC<Props> = ({initMessage}) => {
     updateAuthoredState(changes);
   }
 
+
+  const handleMinMaxChange = (e: React.ChangeEvent<HTMLInputElement>, minMaxKey: keyof IYMinMax) => {
+    setMinMax({...minMax, [minMaxKey]: e.target.value});
+  };
+
   const handleAuthoredAxisBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     let { xMin, xMax, yMin, yMax } = minMax;
 
-    if (e.target.id === "authoredXMin" && xMin > xMax) {
-      xMin = xMax - .1;
-    } else if (e.target.id === "authoredXMax" && xMax < xMin) {
-      xMax = xMin + .1;
-    } else if (e.target.id === "authoredYMin" && yMin > yMax) {
-      yMin = yMax - .1;
-    } else if (e.target.id === "authoredYMax" && yMax < yMin) {
-      yMax = yMin + .1;
+    if (e.target.id === "authoredXMin" && Number(xMin) > Number(xMax)) {
+      xMin = `${Number(xMax) - .1}`;
+    } else if (e.target.id === "authoredXMax" && Number(xMax) < Number(xMin)) {
+      xMax = `${Number(xMin) + .1}`;
+    } else if (e.target.id === "authoredYMin" && Number(yMin) > Number(yMax)) {
+      yMin = `${Number(yMax) - .1}`;
+    } else if (e.target.id === "authoredYMax" && Number(yMax) < Number(yMin)) {
+      yMax = `${Number(yMin) + .1}`;
     }
 
+    // round to nearest 2 decimal places
+    xMin = Number(xMin).toFixed(2);
+    xMax = Number(xMax).toFixed(2);
+    yMin = Number(yMin).toFixed(2);
+    yMax = Number(yMax).toFixed(2);
+
     setMinMax({ xMin, xMax, yMin: yMin, yMax: yMax });
-    const changes: Partial<IAuthoredState> = {authoredMinMax: {authoredXMin: xMin, authoredXMax: xMax, authoredYMin: yMin, authoredYMax: yMax}};
+
+    const changes: Partial<IAuthoredState> = {
+      authoredMinMax: {
+        authoredXMin: Number(xMin),
+        authoredXMax: Number(xMax),
+        authoredYMin: Number(yMin),
+        authoredYMax: Number(yMax)
+      }
+    };
     updateAuthoredState(changes);
   };
 
@@ -342,7 +361,7 @@ export const AuthoringComponent: React.FC<Props> = ({initMessage}) => {
                   id={"authoredXMin"}
                   placeholder="0"
                   value={minMax.xMin}
-                  onChange={(e) => setMinMax({...minMax, xMin: parseFloat(e.target.value)})}
+                  onChange={(e) => handleMinMaxChange(e, "xMin")}
                   onKeyDown={handleAuthoredAxisKeyDown}
                   onBlur={handleAuthoredAxisBlur}
                 />
@@ -353,7 +372,7 @@ export const AuthoringComponent: React.FC<Props> = ({initMessage}) => {
                   id={"authoredXMax"}
                   placeholder="0"
                   value={minMax.xMax}
-                  onChange={(e) => setMinMax({...minMax, xMax: parseFloat(e.target.value)})}
+                  onChange={(e) => handleMinMaxChange(e, "xMax")}
                   onKeyDown={handleAuthoredAxisKeyDown}
                   onBlur={handleAuthoredAxisBlur}
                 />
@@ -366,7 +385,7 @@ export const AuthoringComponent: React.FC<Props> = ({initMessage}) => {
                   id={"authoredYMin"}
                   placeholder="0"
                   value={minMax.yMin}
-                  onChange={(e) => setMinMax({...minMax, yMin: parseFloat(e.target.value)})}
+                  onChange={(e) => handleMinMaxChange(e, "yMin")}
                   onKeyDown={handleAuthoredAxisKeyDown}
                   onBlur={handleAuthoredAxisBlur}
                 />
@@ -377,7 +396,7 @@ export const AuthoringComponent: React.FC<Props> = ({initMessage}) => {
                   id={"authoredYMax"}
                   placeholder="0"
                   value={minMax.yMax}
-                  onChange={(e) => setMinMax({...minMax, yMax: parseFloat(e.target.value)})}
+                  onChange={(e) => handleMinMaxChange(e, "yMax")}
                   onKeyDown={handleAuthoredAxisKeyDown}
                   onBlur={handleAuthoredAxisBlur}
                 />


### PR DESCRIPTION
This PR fixes the following issues:
    - Unable to enter the negative value manually but able to set the negative value using the arrow key
    - Manually Set Graph X-Axes max value is still remembered even after unchecked
    -  Manually set graph X-axis value gets reset after collecting the data and when clicking on the new run
    - The selected and saved sensor type is not remembered in authoring when the us
    - The dropdown menu displays "1s" if xMax is set to a value not in the default dropdown menu