### PR TITLE
fix: Changed GDX sensor variable period calculations [PT-187666947]

### DIFF
--- a/src/models/sensor-gdx-manager.ts
+++ b/src/models/sensor-gdx-manager.ts
@@ -358,7 +358,7 @@ export class SensorGDXManager extends SensorManager {
 
       const deviceMinPeriod = this.getMeasurementPeriod();
       const sensorMinPeriod = this.gdxDevice.sensors?.[0]?.specs?.measurementInfo?.minPeriod ?? 10;
-      const defaultPeriod = Math.max(50, deviceMinPeriod, sensorMinPeriod);
+      const defaultPeriod = Math.max(deviceMinPeriod, sensorMinPeriod);
       const periods: number[] = [... new Set([
         1,
         10,
@@ -370,7 +370,7 @@ export class SensorGDXManager extends SensorManager {
         defaultPeriod,
         deviceMinPeriod,
         sensorMinPeriod
-      ].filter(n => n >= deviceMinPeriod))]
+      ].filter(n => n >= defaultPeriod))]
       periods.sort((a, b) => b - a)
 
       return {


### PR DESCRIPTION
This changes the calculation of the default to be the max of the device or sensor period and does not allow values less than the default.