### PR TITLE
Fix Vernier Light and Color Sensor

### DIFF
--- a/src/components/app.test.ts
+++ b/src/components/app.test.ts
@@ -265,5 +265,51 @@ describe("app", () => {
             })
         });
 
+        it("ignores columns with unknown units", () => {
+            const sensorSlots = [
+                new SensorSlot(0, newSensor({
+                    columnID: "1",
+                    valueUnit: "lux",
+                    sensorPosition: 0
+                })),
+                new SensorSlot(1, newSensor({}))
+            ];
+            const columns: SensorConfigColumnInfo[] = [
+                newColumn({
+                    id: "900",
+                    units: "foo",
+                    position: 0
+                }),
+                newColumn({
+                    id: "901",
+                    units: "degC",
+                    position: 1
+                }),
+                newColumn({
+                    id: "902",
+                    units: "N",
+                    position: 2
+                })
+            ];
+
+            // Ignore console.log calls
+            const mockConsoleLog = jest.spyOn(global.console, "log").mockImplementation(() => null);
+
+            matchSensorsToDataColumns(sensorSlots, columns);
+
+            // None of the columns have a matching unit or matching position.
+            // So the first 2 columns are matched.
+            expect(sensorSlots[0].sensor).toMatchObject({
+                columnID: "901",
+                valueUnit: "degC",
+                sensorPosition: 1
+             })
+            expect(sensorSlots[1].sensor).toMatchObject({
+                columnID: "902",
+                valueUnit: "N",
+                sensorPosition: 2
+            })
+            expect(mockConsoleLog).toBeCalled();
+        });
     })
 });


### PR DESCRIPTION
This sensor was causing the sensor interactive to crash.
It returned multiple sensor types, and most of them had units which are not known. This resulted in an undefined description for the sensor.
The undefined description then caused the code to crash later on.

The solution is identify these unknown unit columns and skip them.

An even better solution to this issue would be to dynmically create the descriptions based on the information provided by Vernier.
However this would require a larger refactoring probably of all of the managers. 

Additionally I cleaned up the handling of the "no interface" case. In this case matchSensorsToDataColumns was called but all it did was reset the two sensors slots.
I checked older versions of the sensor-interactive and found they behaved this same way. In other words this resetting of the sensor slots is not a new behavior.

PT-187841006