### PR TITLE
CODAP-1402 Enable fake sensor via ?fakeSensor=true URL param

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -6,8 +6,13 @@ import App from "./components/app";
 const appElt = document.getElementById("app");
 ReactModal.setAppElement(appElt);
 
+// Allow enabling a fake sensor via a URL parameter (?fakeSensor=true) so the app
+// can be tested without real sensor hardware, for example when running as a CODAP plugin.
+const params = new URLSearchParams(window.location.search);
+const fakeSensor = params.get("fakeSensor") === "true";
+
 ReactDOM.render(
   // By default we will be using sensors.
-  <App useSensors={true} displayType={"line"}/>,
+  <App useSensors={true} displayType={"line"} fakeSensor={fakeSensor}/>,
   appElt
 );


### PR DESCRIPTION
## Summary

Adds support for enabling the fake sensor via a URL query parameter on the deployed standalone build, so the sensor-interactive can be tested without real sensor hardware — for example when running as a CODAP plugin.

`src/app.tsx` now reads `?fakeSensor=true` from `window.location.search` and passes it into the existing `fakeSensor` prop on `App`. The rest of the wiring already exists: `handleWiredClick` / `handleWirelessClick` instantiate `FakeSensorManager` whenever `this.props.fakeSensor` is true. When the param is absent or not exactly `true`, behavior is unchanged (real sensor connection).

## Why

The codebase already has a working `FakeSensorManager`, but it could previously only be enabled via the LARA authoring checkbox (separate `interactive` build, unavailable in the CODAP plugin context) or via the example pages (separate webpack entries that won't embed as the plugin URL). The deployed standalone build hardcoded `fakeSensor` off, and the app reads no URL params, so there was no way to flip it on.

## Testing

Once CI deploys this branch, it can be added to CODAP as a plugin using:

`https://sensorconnector.concord.org/sensor-interactive/branch/CODAP-1402-fake-sensor-url-param/?fakeSensor=true`

Then clicking "Wired Sensor" / "Wireless Sensor" connects the fake sensor and streams synthetic temperature/position data.

- ✅ Webpack dev build compiles successfully.

## Notes

- Scope is limited to the `fakeSensor` param only (per the story). Other test params like `singleReads` / `displayType` are out of scope.

Jira: [CODAP-1402](https://concord-consortium.atlassian.net/browse/CODAP-1402)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CODAP-1402]: https://concord-consortium.atlassian.net/browse/CODAP-1402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ